### PR TITLE
DLS-8349: add navigation from imports to packaging site details when …

### DIFF
--- a/app/controllers/ControllerHelper.scala
+++ b/app/controllers/ControllerHelper.scala
@@ -61,4 +61,20 @@ trait ControllerHelper extends FrontendBaseController with I18nSupport {
         InternalServerError(errorHandler.internalServerErrorTemplate)
     }
   }
+
+  def updateDatabaseWithoutRedirect(updatedAnswers: Try[UserAnswers], page: Page)(success: Future[Result])
+                                   (implicit ec: ExecutionContext, request: Request[AnyContent]): Future[Result] = {
+    updatedAnswers match {
+      case Failure(_) =>
+        genericLogger.logger.error(s"Failed to resolve user answers while on ${page.toString}")
+        Future.successful(InternalServerError(errorHandler.internalServerErrorTemplate))
+      case Success(userAnswers) =>
+        sessionService.set(userAnswers).flatMap {
+          case Right(_) => success
+          case Left(_) =>
+            genericLogger.logger.error(sessionRepo500ErrorMessage(page))
+            Future.successful(InternalServerError)
+        }
+    }
+  }
 }

--- a/app/controllers/changeActivity/ImportsController.scala
+++ b/app/controllers/changeActivity/ImportsController.scala
@@ -16,13 +16,14 @@
 
 package controllers.changeActivity
 
+import connectors.SoftDrinksIndustryLevyConnector
 import controllers.ControllerHelper
 import controllers.actions._
 import forms.changeActivity.ImportsFormProvider
 import handlers.ErrorHandler
-import models.Mode
+import models.{Mode, UserAnswers}
 import navigation._
-import pages.changeActivity.{HowManyImportsPage, ImportsPage}
+import pages.changeActivity.{AmountProducedPage, ContractPackingPage, HowManyImportsPage, ImportsPage}
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.SessionService
@@ -32,6 +33,8 @@ import views.html.changeActivity.ImportsView
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 import models.SelectChange.ChangeActivity
+import models.changeActivity.AmountProduced
+import views.summary.cancelRegistration.FileReturnBeforeDeregSummary
 
 class ImportsController @Inject()(
                                          override val messagesApi: MessagesApi,
@@ -39,6 +42,7 @@ class ImportsController @Inject()(
                                          val navigator: NavigatorForChangeActivity,
                                          controllerActions: ControllerActions,
                                          formProvider: ImportsFormProvider,
+                                         connector: SoftDrinksIndustryLevyConnector,
                                          val controllerComponents: MessagesControllerComponents,
                                          view: ImportsView,
                                           val genericLogger: GenericLogger,
@@ -61,14 +65,29 @@ class ImportsController @Inject()(
   def onSubmit(mode: Mode): Action[AnyContent] = controllerActions.withRequiredJourneyData(ChangeActivity).async {
     implicit request =>
 
+      val userAnswers = request.userAnswers
+
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),
 
         value => {
-          val updatedAnswers = request.userAnswers.setAndRemoveLitresIfReq(ImportsPage, HowManyImportsPage, value)
-          updateDatabaseAndRedirect(updatedAnswers, ImportsPage, mode)
+          val updatedAnswers = userAnswers.setAndRemoveLitresIfReq(ImportsPage, HowManyImportsPage, value)
+          val contractPacker = userAnswers.get(ContractPackingPage).contains(true)
+          val noneProduced = userAnswers.get(AmountProducedPage).contains(AmountProduced.None)
+
+          if(noneProduced && !contractPacker && !value) {
+            updateDatabaseWithoutRedirect(updatedAnswers, ImportsPage)(
+              connector.returns_pending(request.subscription.utr).map {
+                case Some(returns) if returns.nonEmpty =>
+                  Redirect(controllers.cancelRegistration.routes.FileReturnBeforeDeregController.onPageLoad())
+                case _ =>
+                  Redirect(routes.SuggestDeregistrationController.onPageLoad())
+              })
+          } else {
+            updateDatabaseAndRedirect(updatedAnswers, ImportsPage, mode)
           }
+        }
       )
   }
 }

--- a/app/navigation/NavigatorForChangeActivity.scala
+++ b/app/navigation/NavigatorForChangeActivity.scala
@@ -53,10 +53,11 @@ class NavigatorForChangeActivity @Inject()() extends Navigator {
     val noneProduced = userAnswers.get(AmountProducedPage).contains(AmountProduced.None)
     val imports = userAnswers.get(page = ImportsPage).contains(true)
 
-    (noneProduced, contractPacker, imports)match {
-      case (_, _, true) => routes.HowManyImportsController.onPageLoad(mode)
-      case (true, true, false) => routes.PackagingSiteDetailsController.onPageLoad(mode)
-      case _ if mode == CheckMode => routes.ChangeActivityCYAController.onPageLoad
+    (noneProduced, contractPacker, imports, mode) match {
+      case (_, _, true, NormalMode) => routes.HowManyImportsController.onPageLoad(mode)
+      case (true, true, false, NormalMode) => routes.PackagingSiteDetailsController.onPageLoad(mode)
+      case (_, _, true, CheckMode) => routes.HowManyImportsController.onPageLoad(mode)
+      case (_, _, false, CheckMode) => routes.ChangeActivityCYAController.onPageLoad
       case _ => defaultCall
     }
   }

--- a/conf/app.cancelRegistration.routes
+++ b/conf/app.cancelRegistration.routes
@@ -13,8 +13,9 @@ POST       /date                                controllers.cancelRegistration.C
 GET        /change-date                         controllers.cancelRegistration.CancelRegistrationDateController.onPageLoad(mode: Mode = CheckMode)
 POST       /change-date                         controllers.cancelRegistration.CancelRegistrationDateController.onSubmit(mode: Mode = CheckMode)
 
-GET        /reason                                                                     controllers.cancelRegistration.ReasonController.onPageLoad(mode: Mode = NormalMode)
-POST       /reason                                                                     controllers.cancelRegistration.ReasonController.onSubmit(mode: Mode = NormalMode)
-GET        /change-reason                                                              controllers.cancelRegistration.ReasonController.onPageLoad(mode: Mode = CheckMode)
-POST       /change-reason                                                              controllers.cancelRegistration.ReasonController.onSubmit(mode: Mode = CheckMode)
-GET        /file-return-before-deregistration   controllers.cancelRegistration.FileReturnBeforeDeregController.onPageLoad()
+GET        /reason                              controllers.cancelRegistration.ReasonController.onPageLoad(mode: Mode = NormalMode)
+POST       /reason                              controllers.cancelRegistration.ReasonController.onSubmit(mode: Mode = NormalMode)
+GET        /change-reason                       controllers.cancelRegistration.ReasonController.onPageLoad(mode: Mode = CheckMode)
+POST       /change-reason                       controllers.cancelRegistration.ReasonController.onSubmit(mode: Mode = CheckMode)
+
+GET        /file-return-before-deregistration    controllers.cancelRegistration.FileReturnBeforeDeregController.onPageLoad()

--- a/it/controllers/changeActivity/ImportsControllerISpec.scala
+++ b/it/controllers/changeActivity/ImportsControllerISpec.scala
@@ -2,10 +2,11 @@ package controllers.changeActivity
 
 import controllers.ControllerITTestHelper
 import models.SelectChange.ChangeActivity
+import models.changeActivity.AmountProduced
 import models.{CheckMode, NormalMode}
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.{convertToAnyMustWrapper, include}
-import pages.changeActivity.ImportsPage
+import pages.changeActivity.{AmountProducedPage, ContractPackingPage, ImportsPage}
 import play.api.http.HeaderNames
 import play.api.i18n.Messages
 import play.api.libs.json.Json
@@ -129,6 +130,126 @@ class ImportsControllerISpec extends ControllerITTestHelper {
     testUnauthorisedUser(changeActivityBaseUrl + checkRoutePath)
     testAuthenticatedUserButNoUserAnswers(changeActivityBaseUrl + checkRoutePath)
     testAuthenticatedWithUserAnswersForUnsupportedJourneyType(ChangeActivity, changeActivityBaseUrl + checkRoutePath)
+  }
+
+  "in normal mode when amount produced is none" - {
+    "and client is a contract packer" - {
+      "and user answers no to the imports question and submits their answer" - {
+        "they should be redirected to packaging site details" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> false)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.PackagingSiteDetailsController.onPageLoad(NormalMode).url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe false
+            }
+          }
+        }
+      }
+
+      "and answers yes to the imports question and submits their answer" - {
+        "they should be redirected to how many litres imported page" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> true)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.HowManyImportsController.onPageLoad(NormalMode).url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe true
+            }
+          }
+        }
+      }
+    }
+
+    "and client is NOT a contract packer" - {
+      "and answers no to the imports question and submits their answer" - {
+        "they should be redirected to suggest de-registration page if they have no pending returns" in {
+
+          given.noReturnPendingPreCondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> false)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.SuggestDeregistrationController.onPageLoad().url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe false
+            }
+          }
+        }
+
+        "they should be redirected to packaging file return before de-registration page if they have pending returns" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> false)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(controllers.cancelRegistration.routes.FileReturnBeforeDeregController.onPageLoad().url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe false
+            }
+          }
+        }
+      }
+
+      "and answers yes to the imports question and submits their answer" - {
+        "they should be redirected to how many litres imported page" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> true)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.HowManyImportsController.onPageLoad(NormalMode).url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe true
+            }
+          }
+        }
+      }
+    }
   }
 
   s"POST " + normalRoutePath - {

--- a/it/testSupport/preConditions/PreconditionHelpers.scala
+++ b/it/testSupport/preConditions/PreconditionHelpers.scala
@@ -12,6 +12,15 @@ trait PreconditionHelpers {
       .sdilBackend.returns_pending("0000001611")
   }
 
+  def noReturnPendingPreCondition = {
+    builder
+      .user.isAuthorisedAndEnrolled
+      .sdilBackend.retrieveSubscription("utr", "0000001611")
+      .sdilBackend.retrieveSubscription("sdil", "XKSDIL000000022")
+      .sdilBackend.returns_variable("0000001611")
+      .sdilBackend.no_returns_pending("0000001611")
+  }
+
   def unauthorisedPrecondition = {
     builder
       .user.isNotAuthorised()


### PR DESCRIPTION
…coontract packer is true

DLS-8349: add navigation from how amny litres imports WIP

DLS-8349: fix imports test

DLS-8349: add failing tests for desired navigation on imports

DLS-8349: right navigation for deregistration from imports

DLS-8349: right navigation for not contract packer from how  many imports

DLS-8349: check answers are caches correctly

DLS-8349: check answers are cached correctly

DLS-8349: add amounts-produced conditionals