### PR TITLE
DLS-8349: add navigation from imports to packaging site details when …

### DIFF
--- a/app/controllers/ControllerHelper.scala
+++ b/app/controllers/ControllerHelper.scala
@@ -78,19 +78,4 @@ trait ControllerHelper extends FrontendBaseController with I18nSupport {
     }
   }
 
-  def updateDatabaseWithoutRedirect(updatedAnswers: Try[UserAnswers], page: Page)(success: Future[Result])
-                                   (implicit ec: ExecutionContext, request: Request[AnyContent]): Future[Result] = {
-    updatedAnswers match {
-      case Failure(_) =>
-        genericLogger.logger.error(s"Failed to resolve user answers while on ${page.toString}")
-        Future.successful(InternalServerError(errorHandler.internalServerErrorTemplate))
-      case Success(userAnswers) =>
-        sessionService.set(userAnswers).flatMap {
-          case Right(_) => success
-          case Left(_) =>
-            genericLogger.logger.error(sessionRepo500ErrorMessage(page))
-            Future.successful(InternalServerError)
-        }
-    }
-  }
 }

--- a/app/controllers/changeActivity/HowManyImportsController.scala
+++ b/app/controllers/changeActivity/HowManyImportsController.scala
@@ -20,9 +20,9 @@ import controllers.ControllerHelper
 import controllers.actions._
 import forms.HowManyLitresFormProvider
 import handlers.ErrorHandler
-import models.Mode
+import models.{Mode, NormalMode}
 import navigation._
-import pages.changeActivity.HowManyImportsPage
+import pages.changeActivity.{ContractPackingPage, HowManyImportsPage, ImportsPage}
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.SessionService
@@ -67,7 +67,16 @@ class HowManyImportsController @Inject()(
 
         value => {
           val updatedAnswers = request.userAnswers.set(HowManyImportsPage, value)
-          updateDatabaseAndRedirect(updatedAnswers, HowManyImportsPage, mode)
+          val contractPacker = request.userAnswers.get(ContractPackingPage).getOrElse(false)
+          val hasPackagingSites = request.subscription.productionSites.nonEmpty
+
+          (contractPacker, hasPackagingSites, mode) match {
+            case(true, false, NormalMode) =>
+              updateDatabaseWithoutRedirect(updatedAnswers, HowManyImportsPage)(
+                Future.successful(Redirect(routes.PackAtBusinessAddressController.onPageLoad(mode)))
+              )
+            case _ => updateDatabaseAndRedirect(updatedAnswers, HowManyImportsPage, mode)
+          }
         }
       )
   }

--- a/app/controllers/changeActivity/HowManyImportsController.scala
+++ b/app/controllers/changeActivity/HowManyImportsController.scala
@@ -72,9 +72,10 @@ class HowManyImportsController @Inject()(
 
           (contractPacker, hasPackagingSites, mode) match {
             case(true, false, NormalMode) =>
-              updateDatabaseWithoutRedirect(updatedAnswers, HowManyImportsPage)(
-                Future.successful(Redirect(routes.PackAtBusinessAddressController.onPageLoad(mode)))
-              )
+              updateDatabaseWithoutRedirect(updatedAnswers, HowManyImportsPage).flatMap {
+                case true => Future.successful(Redirect(routes.PackAtBusinessAddressController.onPageLoad(mode)))
+                case false => Future.successful(InternalServerError(errorHandler.internalServerErrorTemplate))
+              }
             case _ => updateDatabaseAndRedirect(updatedAnswers, HowManyImportsPage, mode)
           }
         }

--- a/app/controllers/changeActivity/ImportsController.scala
+++ b/app/controllers/changeActivity/ImportsController.scala
@@ -16,13 +16,14 @@
 
 package controllers.changeActivity
 
+import connectors.SoftDrinksIndustryLevyConnector
 import controllers.ControllerHelper
 import controllers.actions._
 import forms.changeActivity.ImportsFormProvider
 import handlers.ErrorHandler
-import models.Mode
+import models.{Mode, UserAnswers}
 import navigation._
-import pages.changeActivity.{HowManyImportsPage, ImportsPage}
+import pages.changeActivity.{AmountProducedPage, ContractPackingPage, HowManyImportsPage, ImportsPage}
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.SessionService
@@ -32,6 +33,8 @@ import views.html.changeActivity.ImportsView
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 import models.SelectChange.ChangeActivity
+import models.changeActivity.AmountProduced
+import views.summary.cancelRegistration.FileReturnBeforeDeregSummary
 
 class ImportsController @Inject()(
                                          override val messagesApi: MessagesApi,
@@ -39,6 +42,7 @@ class ImportsController @Inject()(
                                          val navigator: NavigatorForChangeActivity,
                                          controllerActions: ControllerActions,
                                          formProvider: ImportsFormProvider,
+                                         connector: SoftDrinksIndustryLevyConnector,
                                          val controllerComponents: MessagesControllerComponents,
                                          view: ImportsView,
                                           val genericLogger: GenericLogger,
@@ -61,14 +65,29 @@ class ImportsController @Inject()(
   def onSubmit(mode: Mode): Action[AnyContent] = controllerActions.withRequiredJourneyData(ChangeActivity).async {
     implicit request =>
 
+      val userAnswers = request.userAnswers
+
       form.bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(view(formWithErrors, mode))),
 
         value => {
-          val updatedAnswers = request.userAnswers.setAndRemoveLitresIfReq(ImportsPage, HowManyImportsPage, value)
-          updateDatabaseAndRedirect(updatedAnswers, ImportsPage, mode)
+          val updatedAnswers = userAnswers.setAndRemoveLitresIfReq(ImportsPage, HowManyImportsPage, value)
+          val contractPacker = userAnswers.get(ContractPackingPage).contains(true)
+          val noneProduced = userAnswers.get(AmountProducedPage).contains(AmountProduced.None)
+
+          if(noneProduced && !contractPacker && !value) {
+            updateDatabaseWithoutRedirect(updatedAnswers, ImportsPage)(
+              connector.returns_pending(request.subscription.utr).map {
+                case Some(returns) if returns.nonEmpty =>
+                  Redirect(controllers.cancelRegistration.routes.FileReturnBeforeDeregController.onPageLoad())
+                case _ =>
+                  Redirect(routes.SuggestDeregistrationController.onPageLoad())
+              })
+          } else {
+            updateDatabaseAndRedirect(updatedAnswers, ImportsPage, mode)
           }
+        }
       )
   }
 }

--- a/app/navigation/NavigatorForChangeActivity.scala
+++ b/app/navigation/NavigatorForChangeActivity.scala
@@ -22,14 +22,8 @@ import models.{CheckMode, Mode, NormalMode, UserAnswers}
 import pages.Page
 import pages.changeActivity._
 import play.api.mvc.Call
-import viewmodels.summary.changeActivity.AmountProducedSummary
-import play.api.i18n.Messages
-import play.api.mvc.{Call, RequestHeader}
-import services.{AddressLookupService, PackingDetails}
-import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class NavigatorForChangeActivity @Inject() extends Navigator {
@@ -54,7 +48,7 @@ class NavigatorForChangeActivity @Inject() extends Navigator {
 
   private def navigationForImports(userAnswers: UserAnswers, mode: Mode): Call = {
     val contractPacker = userAnswers.get(ContractPackingPage).contains(true)
-    val noneProduced = userAnswers.get(AmountProducedPage).contains(AmountProduced.None)
+    val noneProduced = userAnswers.get(AmountProducedPage).contains(None)
     val imports = userAnswers.get(page = ImportsPage).contains(true)
 
     (noneProduced, contractPacker, imports, mode) match {
@@ -67,7 +61,7 @@ class NavigatorForChangeActivity @Inject() extends Navigator {
   }
   private def navigationForHowManyImports(userAnswers: UserAnswers, mode: Mode): Call = {
     val contractPacker = userAnswers.get(ContractPackingPage).getOrElse(false)
-    val noneProduced = userAnswers.get(AmountProducedPage).contains(AmountProduced.None)
+    val noneProduced = userAnswers.get(AmountProducedPage).contains(None)
 
     (contractPacker, noneProduced, mode) match {
       case (true, true, NormalMode) => routes.PackagingSiteDetailsController.onPageLoad(mode)

--- a/app/navigation/NavigatorForChangeActivity.scala
+++ b/app/navigation/NavigatorForChangeActivity.scala
@@ -66,12 +66,12 @@ class NavigatorForChangeActivity @Inject() extends Navigator {
     }
   }
   private def navigationForHowManyImports(userAnswers: UserAnswers, mode: Mode): Call = {
-    val contractPacker = userAnswers.get(ContractPackingPage).contains(true)
+    val contractPacker = userAnswers.get(ContractPackingPage).getOrElse(false)
     val noneProduced = userAnswers.get(AmountProducedPage).contains(AmountProduced.None)
 
     (contractPacker, noneProduced, mode) match {
-      case (true, true, _) => routes.PackagingSiteDetailsController.onPageLoad(mode)
-      case (false, true, NormalMode) => routes.SecondaryWarehouseDetailsController.onPageLoad(NormalMode)
+      case (true, true, NormalMode) => routes.PackagingSiteDetailsController.onPageLoad(mode)
+      case (false, true, NormalMode) => routes.SecondaryWarehouseDetailsController.onPageLoad(mode)
       case _ => routes.ChangeActivityCYAController.onPageLoad
     }
   }

--- a/app/navigation/NavigatorForChangeActivity.scala
+++ b/app/navigation/NavigatorForChangeActivity.scala
@@ -21,6 +21,8 @@ import models.changeActivity.AmountProduced._
 import models.{CheckMode, Mode, NormalMode, UserAnswers}
 import pages.Page
 import pages.changeActivity._
+import play.api.mvc.Call
+import viewmodels.summary.changeActivity.AmountProducedSummary
 import play.api.i18n.Messages
 import play.api.mvc.{Call, RequestHeader}
 import services.{AddressLookupService, PackingDetails}
@@ -51,12 +53,26 @@ class NavigatorForChangeActivity @Inject() extends Navigator {
   }
 
   private def navigationForImports(userAnswers: UserAnswers, mode: Mode): Call = {
-    if (userAnswers.get(page = ImportsPage).contains(true)) {
-      routes.HowManyImportsController.onPageLoad(mode)
-    } else if(mode == CheckMode){
-        routes.ChangeActivityCYAController.onPageLoad
-    } else {
-        defaultCall
+    val contractPacker = userAnswers.get(ContractPackingPage).contains(true)
+    val noneProduced = userAnswers.get(AmountProducedPage).contains(AmountProduced.None)
+    val imports = userAnswers.get(page = ImportsPage).contains(true)
+
+    (noneProduced, contractPacker, imports, mode) match {
+      case (_, _, true, NormalMode) => routes.HowManyImportsController.onPageLoad(mode)
+      case (true, true, false, NormalMode) => routes.PackagingSiteDetailsController.onPageLoad(mode)
+      case (_, _, true, CheckMode) => routes.HowManyImportsController.onPageLoad(mode)
+      case (_, _, false, CheckMode) => routes.ChangeActivityCYAController.onPageLoad
+      case _ => defaultCall
+    }
+  }
+  private def navigationForHowManyImports(userAnswers: UserAnswers, mode: Mode): Call = {
+    val contractPacker = userAnswers.get(ContractPackingPage).contains(true)
+    val noneProduced = userAnswers.get(AmountProducedPage).contains(AmountProduced.None)
+
+    (contractPacker, noneProduced, mode) match {
+      case (true, true, _) => routes.PackagingSiteDetailsController.onPageLoad(mode)
+      case (false, true, NormalMode) => routes.SecondaryWarehouseDetailsController.onPageLoad(NormalMode)
+      case _ => routes.ChangeActivityCYAController.onPageLoad
     }
   }
 
@@ -93,12 +109,13 @@ class NavigatorForChangeActivity @Inject() extends Navigator {
   override val normalRoutes: Page => UserAnswers => Call = {
     case ThirdPartyPackagersPage => _ => navigationForOperateThirdPartyPackagers(NormalMode)
     case PackAtBusinessAddressPage => _ => defaultCall
+    case PackagingSiteDetailsPage => _ => defaultCall
     case RemovePackagingSiteDetailsPage => _ => routes.PackagingSiteDetailsController.onPageLoad(NormalMode)
     case SecondaryWarehouseDetailsPage => _ => defaultCall
     case ContractPackingPage => userAnswers => navigationForContractPacking(userAnswers, NormalMode)
     case HowManyContractPackingPage => userAnswers => navigationForHowManyContractPacking(userAnswers, NormalMode)
     case ImportsPage => userAnswers => navigationForImports(userAnswers, NormalMode)
-    case HowManyImportsPage => _ => defaultCall
+    case HowManyImportsPage => userAnswers => navigationForHowManyImports(userAnswers, NormalMode)
     case OperatePackagingSiteOwnBrandsPage => userAnswers => navigationForOperatePackagingSiteOwnBrands(userAnswers, NormalMode)
     case HowManyOperatePackagingSiteOwnBrandsPage => _ => routes.ContractPackingController.onPageLoad(NormalMode)
     case AmountProducedPage => userAnswers => navigationForAmountProduced(userAnswers, NormalMode)
@@ -112,6 +129,7 @@ class NavigatorForChangeActivity @Inject() extends Navigator {
     case RemovePackagingSiteDetailsPage => _ => routes.PackagingSiteDetailsController.onPageLoad(CheckMode)
     case ContractPackingPage => userAnswers => navigationForContractPacking(userAnswers, CheckMode)
     case ImportsPage => userAnswers => navigationForImports(userAnswers, CheckMode)
+    case HowManyImportsPage => userAnswers => navigationForHowManyImports(userAnswers, CheckMode)
     case OperatePackagingSiteOwnBrandsPage => userAnswers => navigationForOperatePackagingSiteOwnBrands(userAnswers, CheckMode)
     case HowManyOperatePackagingSiteOwnBrandsPage => _ => routes.ChangeActivityCYAController.onPageLoad
     case _ => _ => routes.ChangeActivityCYAController.onPageLoad

--- a/conf/app.cancelRegistration.routes
+++ b/conf/app.cancelRegistration.routes
@@ -13,8 +13,9 @@ POST       /date                                controllers.cancelRegistration.C
 GET        /change-date                         controllers.cancelRegistration.CancelRegistrationDateController.onPageLoad(mode: Mode = CheckMode)
 POST       /change-date                         controllers.cancelRegistration.CancelRegistrationDateController.onSubmit(mode: Mode = CheckMode)
 
-GET        /reason                                                                     controllers.cancelRegistration.ReasonController.onPageLoad(mode: Mode = NormalMode)
-POST       /reason                                                                     controllers.cancelRegistration.ReasonController.onSubmit(mode: Mode = NormalMode)
-GET        /change-reason                                                              controllers.cancelRegistration.ReasonController.onPageLoad(mode: Mode = CheckMode)
-POST       /change-reason                                                              controllers.cancelRegistration.ReasonController.onSubmit(mode: Mode = CheckMode)
-GET        /file-return-before-deregistration   controllers.cancelRegistration.FileReturnBeforeDeregController.onPageLoad()
+GET        /reason                              controllers.cancelRegistration.ReasonController.onPageLoad(mode: Mode = NormalMode)
+POST       /reason                              controllers.cancelRegistration.ReasonController.onSubmit(mode: Mode = NormalMode)
+GET        /change-reason                       controllers.cancelRegistration.ReasonController.onPageLoad(mode: Mode = CheckMode)
+POST       /change-reason                       controllers.cancelRegistration.ReasonController.onSubmit(mode: Mode = CheckMode)
+
+GET        /file-return-before-deregistration    controllers.cancelRegistration.FileReturnBeforeDeregController.onPageLoad()

--- a/it/controllers/changeActivity/HowManyImportsControllerISpec.scala
+++ b/it/controllers/changeActivity/HowManyImportsControllerISpec.scala
@@ -2,10 +2,11 @@ package controllers.changeActivity
 
 import controllers.LitresISpecHelper
 import models.SelectChange.ChangeActivity
+import models.changeActivity.AmountProduced
 import models.{CheckMode, LitresInBands, NormalMode, UserAnswers}
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.{convertToAnyMustWrapper, include}
-import pages.changeActivity.HowManyImportsPage
+import pages.changeActivity.{AmountProducedPage, ContractPackingPage, HowManyImportsPage, ImportsPage}
 import play.api.http.HeaderNames
 import play.api.i18n.Messages
 import play.api.libs.json.Json
@@ -20,10 +21,10 @@ class HowManyImportsControllerISpec extends LitresISpecHelper {
   val userAnswers: UserAnswers = emptyUserAnswersForChangeActivity.set(HowManyImportsPage, litresInBands).success.value
 
   List(NormalMode, CheckMode).foreach { mode =>
-    val (path, redirectLocation) = if(mode == NormalMode) {
-      (normalRoutePath, defaultCall.url)
+    val (path) = if(mode == NormalMode) {
+      (normalRoutePath)
     } else {
-      (checkRoutePath, routes.ChangeActivityCYAController.onPageLoad.url)
+      (checkRoutePath)
     }
 
     "GET " + path - {
@@ -72,49 +73,6 @@ class HowManyImportsControllerISpec extends LitresISpecHelper {
     }
 
     s"POST " + path - {
-      "when the user populates all litres fields" - {
-        "should update the session with the new values and redirect to " + redirectLocation - {
-          "when the session contains no data for page" in {
-            given
-              .commonPrecondition
-
-            setAnswers(emptyUserAnswersForChangeActivity)
-            WsTestClient.withClient { client =>
-              val result = createClientRequestPOST(
-                client, changeActivityBaseUrl + path, Json.toJson(litresInBands)
-              )
-
-              whenReady(result) { res =>
-                res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(redirectLocation)
-                val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
-                dataStoredForPage.nonEmpty mustBe true
-                dataStoredForPage.get mustBe litresInBands
-              }
-            }
-          }
-
-          "when the session already contains data for page" in {
-            given
-              .commonPrecondition
-
-            setAnswers(userAnswers)
-            WsTestClient.withClient { client =>
-              val result = createClientRequestPOST(
-                client, changeActivityBaseUrl + path, Json.toJson(litresInBandsDiff)
-              )
-
-              whenReady(result) { res =>
-                res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(redirectLocation)
-                val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
-                dataStoredForPage.nonEmpty mustBe true
-                dataStoredForPage.get mustBe litresInBandsDiff
-              }
-            }
-          }
-        }
-      }
 
       "should return 400 with required error" - {
         val errorTitle = "Error: " + Messages("howManyImports.title")
@@ -213,6 +171,159 @@ class HowManyImportsControllerISpec extends LitresISpecHelper {
       testUnauthorisedUser(changeActivityBaseUrl + path, Some(Json.toJson(litresInBandsDiff)))
       testAuthenticatedUserButNoUserAnswers(changeActivityBaseUrl + path, Some(Json.toJson(litresInBandsDiff)))
       testAuthenticatedWithUserAnswersForUnsupportedJourneyType(ChangeActivity, changeActivityBaseUrl + path, Some(Json.toJson(litresInBandsDiff)))
+    }
+  }
+
+
+  "in normal mode when amount produced is none" - {
+    "and client is a contract packer" - {
+      "and adds import litres and submits their answer" - {
+        "they should be redirected to packaging site details" in {
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(ImportsPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.toJson(litresInBands)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.PackagingSiteDetailsController.onPageLoad(NormalMode).url)
+              val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
+              dataStoredForPage.get mustBe litresInBands
+            }
+          }
+        }
+      }
+    }
+
+    "and client is NOT a contract packer" - {
+      "and adds import litres and submits their answer" - {
+        "they should be redirected to secondary warehouse details" in {
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(ImportsPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.toJson(litresInBands)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.SecondaryWarehouseDetailsController.onPageLoad(NormalMode).url)
+              val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
+              dataStoredForPage.get mustBe litresInBands
+            }
+          }
+        }
+      }
+    }
+  }
+
+  "in check mode when amount produced is none" - {
+    "and client is a contract packer" - {
+      "and changes existing import litres and submits their answer" - {
+        "they should be redirected to packaging site details" in {
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(ImportsPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value
+            .set(HowManyImportsPage, LitresInBands(2L,2L)).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + checkRoutePath, Json.toJson(litresInBands)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.PackagingSiteDetailsController.onPageLoad(CheckMode).url)
+              val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
+              dataStoredForPage.get mustBe litresInBands
+            }
+          }
+        }
+      }
+
+      "and adds import litres (with no previous data) and submits their answer" - {
+        "they should be redirected to packaging site details" in {
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(ImportsPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + checkRoutePath, Json.toJson(litresInBands)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.PackagingSiteDetailsController.onPageLoad(CheckMode).url)
+              val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
+              dataStoredForPage.get mustBe litresInBands
+            }
+          }
+        }
+      }
+    }
+
+    "and client is NOT a contract packer" - {
+      "and changes existing import litres and submits their answer" - {
+        "they should be redirected to check your answers page" in {
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(ImportsPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value
+            .set(HowManyImportsPage, LitresInBands(2L, 2L)).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + checkRoutePath, Json.toJson(litresInBands)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.ChangeActivityCYAController.onPageLoad.url)
+              val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
+              dataStoredForPage.get mustBe litresInBands
+            }
+          }
+        }
+      }
+
+      "and adds import litres (with no previous data) and submits their answer" - {
+        "they should be redirected to check your answers page" in {
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(ImportsPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + checkRoutePath, Json.toJson(litresInBands)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.ChangeActivityCYAController.onPageLoad.url)
+              val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
+              dataStoredForPage.get mustBe litresInBands
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/it/controllers/changeActivity/ImportsControllerISpec.scala
+++ b/it/controllers/changeActivity/ImportsControllerISpec.scala
@@ -360,6 +360,55 @@ class ImportsControllerISpec extends ControllerITTestHelper with LitresISpecHelp
       }
     }
 
+    "and client is a contract packer but has no production sites" - {
+      "and user answers no to the imports question and submits their answer" - {
+        "they should be redirected to pack at business address" in {
+
+          given.commonPreconditionChangeSubscription(aSubscription)
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> false)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.PackAtBusinessAddressController.onPageLoad(NormalMode).url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe false
+            }
+          }
+        }
+      }
+
+      "and answers yes to the imports question and submits their answer" - {
+        "they should be redirected to how many litres imported page" in {
+
+          given.commonPreconditionChangeSubscription(aSubscription)
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> true)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.HowManyImportsController.onPageLoad(NormalMode).url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe true
+            }
+          }
+        }
+      }
+    }
+
     "and client is NOT a contract packer" - {
       "and answers no to the imports question and submits their answer" - {
         "they should be redirected to suggest de-registration page if they have no pending returns" in {
@@ -538,7 +587,7 @@ class ImportsControllerISpec extends ControllerITTestHelper with LitresISpecHelp
         }
       }
 
-      "aand user changes a previous no answer to imports to yes" - {
+      "and user changes a previous no answer to imports to yes" - {
         "they should be redirected to how many litres imported page" in {
 
           given.commonPrecondition

--- a/it/controllers/changeActivity/ImportsControllerISpec.scala
+++ b/it/controllers/changeActivity/ImportsControllerISpec.scala
@@ -1,17 +1,18 @@
 package controllers.changeActivity
 
-import controllers.ControllerITTestHelper
+import controllers.{ControllerITTestHelper, LitresISpecHelper}
 import models.SelectChange.ChangeActivity
-import models.{CheckMode, NormalMode}
+import models.changeActivity.AmountProduced
+import models.{CheckMode, LitresInBands, NormalMode}
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.{convertToAnyMustWrapper, include}
-import pages.changeActivity.ImportsPage
+import pages.changeActivity.{AmountProducedPage, ContractPackingPage, HowManyImportsPage, ImportsPage}
 import play.api.http.HeaderNames
 import play.api.i18n.Messages
 import play.api.libs.json.Json
 import play.api.test.WsTestClient
 
-class ImportsControllerISpec extends ControllerITTestHelper {
+class ImportsControllerISpec extends ControllerITTestHelper with LitresISpecHelper {
 
   val normalRoutePath = "/imports"
   val checkRoutePath = "/change-imports"
@@ -307,5 +308,259 @@ class ImportsControllerISpec extends ControllerITTestHelper {
     testUnauthorisedUser(changeActivityBaseUrl + checkRoutePath, Some(Json.obj("value" -> "true")))
     testAuthenticatedUserButNoUserAnswers(changeActivityBaseUrl + checkRoutePath, Some(Json.obj("value" -> "true")))
     testAuthenticatedWithUserAnswersForUnsupportedJourneyType(ChangeActivity, changeActivityBaseUrl + checkRoutePath, Some(Json.obj("value" -> "true")))
+  }
+
+  "in normal mode when amount produced is none" - {
+    "and client is a contract packer" - {
+      "and user answers no to the imports question and submits their answer" - {
+        "they should be redirected to packaging site details" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> false)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.PackagingSiteDetailsController.onPageLoad(NormalMode).url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe false
+            }
+          }
+        }
+      }
+
+      "and answers yes to the imports question and submits their answer" - {
+        "they should be redirected to how many litres imported page" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> true)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.HowManyImportsController.onPageLoad(NormalMode).url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe true
+            }
+          }
+        }
+      }
+    }
+
+    "and client is NOT a contract packer" - {
+      "and answers no to the imports question and submits their answer" - {
+        "they should be redirected to suggest de-registration page if they have no pending returns" in {
+
+          given.noReturnPendingPreCondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> false)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.SuggestDeregistrationController.onPageLoad().url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe false
+            }
+          }
+        }
+
+        "they should be redirected to packaging file return before de-registration page if they have pending returns" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> false)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(controllers.cancelRegistration.routes.FileReturnBeforeDeregController.onPageLoad().url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe false
+            }
+          }
+        }
+      }
+
+      "and answers yes to the imports question and submits their answer" - {
+        "they should be redirected to how many litres imported page" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + normalRoutePath, Json.obj("value" -> true)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.HowManyImportsController.onPageLoad(NormalMode).url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe true
+            }
+          }
+        }
+      }
+    }
+  }
+
+  "in check mode when amount produced is none" - {
+    "and client is a contract packer" - {
+      "and user changes a previous yes answer to imports to no" - {
+        "they should be redirected to check your answers" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value
+            .set(ImportsPage, true).success.value
+            .set(HowManyImportsPage, litresInBands).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + checkRoutePath, Json.obj("value" -> false)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.ChangeActivityCYAController.onPageLoad.url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              val dataStoredForLitres = getAnswers(sdilNumber).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
+              dataStoredForPage.get mustBe false
+              dataStoredForLitres mustBe None
+            }
+          }
+        }
+      }
+
+      "and user changes a previous no answer to imports to yes" - {
+        "they should be redirected to how many litres imported page" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, true).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value
+            .set(ImportsPage, false).success.value)
+
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + checkRoutePath, Json.obj("value" -> true)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.HowManyImportsController.onPageLoad(CheckMode).url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe true
+            }
+          }
+        }
+      }
+    }
+
+    "and client is NOT a contract packer" - {
+      "and user changes a previous yes answer to imports to no" - {
+        "they should be redirected to suggest de-registration page if they have no pending returns" in {
+
+          given.noReturnPendingPreCondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value
+            .set(ImportsPage, true).success.value
+            .set(HowManyImportsPage, litresInBands).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + checkRoutePath, Json.obj("value" -> false)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.SuggestDeregistrationController.onPageLoad().url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              val dataStoredForLitres = getAnswers(sdilNumber).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
+              dataStoredForPage.get mustBe false
+              dataStoredForLitres mustBe None
+            }
+          }
+        }
+
+        "they should be redirected to packaging file return before de-registration page if they have pending returns" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value
+            .set(ImportsPage, true).success.value
+            .set(HowManyImportsPage, litresInBands).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + checkRoutePath, Json.obj("value" -> false)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(controllers.cancelRegistration.routes.FileReturnBeforeDeregController.onPageLoad().url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              val dataStoredForLitres = getAnswers(sdilNumber).fold[Option[LitresInBands]](None)(_.get(HowManyImportsPage))
+              dataStoredForPage.get mustBe false
+              dataStoredForLitres mustBe None
+            }
+          }
+        }
+      }
+
+      "aand user changes a previous no answer to imports to yes" - {
+        "they should be redirected to how many litres imported page" in {
+
+          given.commonPrecondition
+          setAnswers(emptyUserAnswersForChangeActivity
+            .set(ContractPackingPage, false).success.value
+            .set(AmountProducedPage, AmountProduced.None).success.value
+            .set(ImportsPage, false).success.value)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestPOST(
+              client, changeActivityBaseUrl + checkRoutePath, Json.obj("value" -> true)
+            )
+
+            whenReady(result) { res =>
+              res.status mustBe 303
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.HowManyImportsController.onPageLoad(CheckMode).url)
+              val dataStoredForPage = getAnswers(sdilNumber).fold[Option[Boolean]](None)(_.get(ImportsPage))
+              dataStoredForPage.get mustBe true
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/it/testSupport/ITCoreTestData.scala
+++ b/it/testSupport/ITCoreTestData.scala
@@ -1,6 +1,7 @@
 package testSupport
 
 import controllers.routes
+import models.{Contact, RetrievedActivity, RetrievedSubscription}
 import models.backend.{Site, UkAddress}
 import org.scalatest.TryValues
 import play.api.libs.json.Json
@@ -36,4 +37,17 @@ trait ITCoreTestData
   implicit val duration = 5.seconds
 
   val defaultCall = routes.IndexController.onPageLoad
+
+  val aSubscription = RetrievedSubscription(
+    utr = "0000001611",
+    sdilRef = "XKSDIL000000022",
+    orgName = "Super Lemonade Plc",
+    address = UkAddress(List("63 Clifton Roundabout", "Worcester"), "WR53 7CX"),
+    activity = RetrievedActivity(smallProducer = false, largeProducer = true, contractPacker = false, importer = false, voluntaryRegistration = false),
+    liabilityDate = LocalDate.of(2018, 4, 19),
+    productionSites = List(),
+    warehouseSites = List(),
+    contact = Contact(Some("Ava Adams"), Some("Chief Infrastructure Agent"), "04495 206189", "Adeline.Greene@gmail.com"),
+    deregDate = None
+  )
 }

--- a/it/testSupport/preConditions/PreconditionHelpers.scala
+++ b/it/testSupport/preConditions/PreconditionHelpers.scala
@@ -1,5 +1,7 @@
 package testSupport.preConditions
 
+import models.RetrievedSubscription
+
 trait PreconditionHelpers {
   implicit val builder: PreconditionBuilder
 
@@ -9,6 +11,13 @@ trait PreconditionHelpers {
       .sdilBackend.retrieveSubscription("utr","0000001611")
       .sdilBackend.retrieveSubscription("sdil","XKSDIL000000022")
       .sdilBackend.returns_variable("0000001611")
+      .sdilBackend.returns_pending("0000001611")
+  }
+
+  def commonPreconditionChangeSubscription(retrievedSubscription: RetrievedSubscription): PreconditionBuilder = {
+    builder
+      .user.isAuthorisedAndEnrolled
+      .sdilBackend.retrieveSubscriptionToModify("utr", "0000001611", retrievedSubscription)
       .sdilBackend.returns_pending("0000001611")
   }
 

--- a/it/testSupport/preConditions/PreconditionHelpers.scala
+++ b/it/testSupport/preConditions/PreconditionHelpers.scala
@@ -12,6 +12,15 @@ trait PreconditionHelpers {
       .sdilBackend.returns_pending("0000001611")
   }
 
+  def noReturnPendingPreCondition = {
+    builder
+      .user.isAuthorisedAndEnrolled
+      .sdilBackend.retrieveSubscription("utr", "0000001611")
+      .sdilBackend.retrieveSubscription("sdil", "XKSDIL000000022")
+      .sdilBackend.returns_variable("0000001611")
+      .sdilBackend.no_returns_pending("0000001611")
+  }
+
   def unauthorisedPrecondition = {
     builder
       .user.isNotAuthorised()

--- a/it/testSupport/preConditions/SdilBackendStub.scala
+++ b/it/testSupport/preConditions/SdilBackendStub.scala
@@ -100,5 +100,13 @@ case class SdilBackendStub()
     builder
   }
 
+  def retrieveSubscriptionToModify(identifier: String, refNum: String, retrievedSubscription: RetrievedSubscription): PreconditionBuilder = {
+    stubFor(
+      get(
+        urlPathMatching(s"/subscription/$identifier/$refNum"))
+        .willReturn(
+          ok(Json.toJson(retrievedSubscription).toString())))
+    builder
+  }
 }
 


### PR DESCRIPTION
…coontract packer is true

DLS-8349: add navigation from how amny litres imports WIP

DLS-8349: fix imports test

DLS-8349: add failing tests for desired navigation on imports

DLS-8349: right navigation for deregistration from imports

DLS-8349: right navigation for not contract packer from how  many imports

DLS-8349: check answers are caches correctly

DLS-8349: check answers are cached correctly

DLS-8349: add amounts-produced conditionals

DLS-8349: add imports change navigation WIP

DLS-8349: complete imports change navigation

DLS-8349: refactor how many imports change navigation