### PR TITLE
Dls 7741 check change update

### DIFF
--- a/app/controllers/correctReturn/CorrectReturnCheckChangesCYAController.scala
+++ b/app/controllers/correctReturn/CorrectReturnCheckChangesCYAController.scala
@@ -47,9 +47,9 @@ class CorrectReturnCheckChangesCYAController @Inject()(
       val currentSDILReturn = SdilReturn.apply(request.userAnswers)
       println(Console.BLUE + "Orig SDIL return is  " + originalSDILReturn + Console.WHITE)
       println(Console.BLUE + "Current SDIL return is  " + currentSDILReturn + Console.WHITE)
-      val sections = CorrectReturnBaseCYASummary.summaryListAndHeadings(request.userAnswers, request.subscription)
       val changedPages = ChangedPage.returnLiteragePagesThatChangedComparedToOriginalReturn(originalSDILReturn, currentSDILReturn)
-      println(Console.MAGENTA + "changed pages  " + changedPages + Console.WHITE)
+      val sections = CorrectReturnBaseCYASummary.changedSummaryListAndHeadings(request.userAnswers, request.subscription, changedPages)
+       println(Console.MAGENTA + "changed pages  " + changedPages + Console.WHITE)
       Ok(view(orgName, sections, routes.CorrectReturnCheckChangesCYAController.onSubmit))
   }
 

--- a/app/controllers/correctReturn/CorrectReturnCheckChangesCYAController.scala
+++ b/app/controllers/correctReturn/CorrectReturnCheckChangesCYAController.scala
@@ -42,6 +42,7 @@ class CorrectReturnCheckChangesCYAController @Inject()(
   def onPageLoad(): Action[AnyContent] = controllerActions.withCorrectReturnJourneyData {
     implicit request =>
       val orgName: String = " " + request.subscription.orgName
+      println(Console.YELLOW + request.userAnswers + Console.WHITE)
       val originalSDILReturn = request.userAnswers.getCorrectReturnOriginalSDILReturnData.get
       val currentSDILReturn = SdilReturn.apply(request.userAnswers)
       val changedPages = ChangedPage.returnLiteragePagesThatChangedComparedToOriginalReturn(originalSDILReturn, currentSDILReturn)

--- a/app/controllers/correctReturn/CorrectReturnCheckChangesCYAController.scala
+++ b/app/controllers/correctReturn/CorrectReturnCheckChangesCYAController.scala
@@ -41,15 +41,16 @@ class CorrectReturnCheckChangesCYAController @Inject()(
 
   def onPageLoad(): Action[AnyContent] = controllerActions.withCorrectReturnJourneyData {
     implicit request =>
-      val orgName: String = " " + request.subscription.orgName
-      println(Console.YELLOW + request.userAnswers + Console.WHITE)
-      val originalSDILReturn = request.userAnswers.getCorrectReturnOriginalSDILReturnData.get
-      val currentSDILReturn = SdilReturn.apply(request.userAnswers)
-      val changedPages = ChangedPage.returnLiteragePagesThatChangedComparedToOriginalReturn(originalSDILReturn, currentSDILReturn)
-      val sections = CorrectReturnBaseCYASummary.changedSummaryListAndHeadings(request.userAnswers, request.subscription, changedPages)
+      request.userAnswers.getCorrectReturnOriginalSDILReturnData.map(originalSdilReturn => {
+        val orgName: String = " " + request.subscription.orgName
+        val currentSDILReturn = SdilReturn.apply(request.userAnswers)
+        val changedPages = ChangedPage.returnLiteragePagesThatChangedComparedToOriginalReturn(originalSdilReturn, currentSDILReturn)
+        val sections = CorrectReturnBaseCYASummary.changedSummaryListAndHeadings(request.userAnswers, request.subscription, changedPages)
 
-      Ok(view(orgName, sections, routes.CorrectReturnCheckChangesCYAController.onSubmit))
+        Ok(view(orgName, sections, routes.CorrectReturnCheckChangesCYAController.onSubmit))
+      }).getOrElse(Redirect(controllers.routes.SelectChangeController.onPageLoad.url))
   }
+
 
   def onSubmit: Action[AnyContent] = controllerActions.withRequiredJourneyData(CorrectReturn) {
     Redirect(controllers.routes.IndexController.onPageLoad.url)

--- a/app/controllers/correctReturn/CorrectReturnCheckChangesCYAController.scala
+++ b/app/controllers/correctReturn/CorrectReturnCheckChangesCYAController.scala
@@ -41,15 +41,12 @@ class CorrectReturnCheckChangesCYAController @Inject()(
 
   def onPageLoad(): Action[AnyContent] = controllerActions.withCorrectReturnJourneyData {
     implicit request =>
-      println(Console.YELLOW + "User answers are " + request.userAnswers + Console.WHITE)
       val orgName: String = " " + request.subscription.orgName
       val originalSDILReturn = request.userAnswers.getCorrectReturnOriginalSDILReturnData.get
       val currentSDILReturn = SdilReturn.apply(request.userAnswers)
-      println(Console.BLUE + "Orig SDIL return is  " + originalSDILReturn + Console.WHITE)
-      println(Console.BLUE + "Current SDIL return is  " + currentSDILReturn + Console.WHITE)
       val changedPages = ChangedPage.returnLiteragePagesThatChangedComparedToOriginalReturn(originalSDILReturn, currentSDILReturn)
       val sections = CorrectReturnBaseCYASummary.changedSummaryListAndHeadings(request.userAnswers, request.subscription, changedPages)
-       println(Console.MAGENTA + "changed pages  " + changedPages + Console.WHITE)
+
       Ok(view(orgName, sections, routes.CorrectReturnCheckChangesCYAController.onSubmit))
   }
 

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -51,7 +51,7 @@ case class UserAnswers(
   }
 
   def getCorrectReturnOriginalSDILReturnData(implicit rds: Reads[SdilReturn]): Option[SdilReturn] = {
-    val jsPath = JsPath \ "OriginalSDILReturn"
+    val jsPath = JsPath \ "originalSDILReturn"
     Reads.optionNoError(Reads.at(jsPath)).reads(data).getOrElse(None)
   }
 
@@ -97,7 +97,7 @@ case class UserAnswers(
   def setOriginalSDILReturn(originalSDILReturn: SdilReturn)
                                  (implicit writes: Writes[CorrectReturnUserAnswersData]): Try[UserAnswers] = {
 
-    val jsPath = JsPath \ "OriginalSDILReturn"
+    val jsPath = JsPath \ "originalSDILReturn"
 
     val updatedData = data.setObject(jsPath, Json.toJson(originalSDILReturn)) match {
       case JsSuccess(jsValue, _) =>

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -50,6 +50,11 @@ case class UserAnswers(
     Reads.optionNoError(Reads.at(jsPath)).reads(data).getOrElse(None)
   }
 
+  def getCorrectReturnOriginalSDILReturnData(implicit rds: Reads[SdilReturn]): Option[SdilReturn] = {
+    val jsPath = JsPath \ "OriginalSDILReturn"
+    Reads.optionNoError(Reads.at(jsPath)).reads(data).getOrElse(None)
+  }
+
   def set[A](page: Settable[A], value: A)(implicit writes: Writes[A]): Try[UserAnswers] = {
 
     val updatedData = data.setObject(page.path, Json.toJson(value)) match {
@@ -85,6 +90,25 @@ case class UserAnswers(
         val updatedAnswers = copy(data = d,
           smallProducerList = smallProducers,
           correctReturnPeriod = Some(returnPeriod))
+        Success(updatedAnswers)
+    }
+  }
+
+  def setOriginalSDILReturn(originalSDILReturn: SdilReturn)
+                                 (implicit writes: Writes[CorrectReturnUserAnswersData]): Try[UserAnswers] = {
+
+    val jsPath = JsPath \ "OriginalSDILReturn"
+
+    val updatedData = data.setObject(jsPath, Json.toJson(originalSDILReturn)) match {
+      case JsSuccess(jsValue, _) =>
+        Success(jsValue)
+      case JsError(errors) =>
+        Failure(JsResultException(errors))
+    }
+
+    updatedData.flatMap {
+      d =>
+        val updatedAnswers = copy(data = d)
         Success(updatedAnswers)
     }
   }

--- a/app/models/correctReturn/ChangedPage.scala
+++ b/app/models/correctReturn/ChangedPage.scala
@@ -64,6 +64,14 @@ case class ChangedPage(page: Page, answerChanged: Boolean)
           answerChanged = original.export != current.export
         ),
         ChangedPage(
+          page = ClaimCreditsForLostDamagedPage,
+          answerChanged = original.wastage != current.wastage
+        ),
+        ChangedPage(
+          page = HowManyCreditsForLostDamagedPage,
+          answerChanged = original.wastage != current.wastage
+        ),
+        ChangedPage(
           page = ExemptionsForSmallProducersPage,
           answerChanged = SmallProducer.totalOfAllSmallProducers(original.packSmall) != SmallProducer.totalOfAllSmallProducers(current.packSmall)
         )

--- a/app/orchestrators/CorrectReturnOrchestrator.scala
+++ b/app/orchestrators/CorrectReturnOrchestrator.scala
@@ -48,7 +48,8 @@ class CorrectReturnOrchestrator @Inject()(connector: SoftDrinksIndustryLevyConne
 
     for {
       sdilReturn <- getSdilReturn(retrievedSubscription, selectedReturnPeriod)
-      updatedUserAnswers <- generateUserAnswersWithSdilReturn(userAnswers, sdilReturn, selectedReturnPeriod)
+      updatedUserAnswersWithSavedSdilReturn <- generateUAsWithSavedSdilReturn(userAnswers, sdilReturn)
+      updatedUserAnswers <- generateUserAnswersWithSdilReturn(updatedUserAnswersWithSavedSdilReturn, sdilReturn, selectedReturnPeriod)
       _ <- EitherT(sessionService.set(updatedUserAnswers))
     } yield (): Unit
 
@@ -66,7 +67,7 @@ class CorrectReturnOrchestrator @Inject()(connector: SoftDrinksIndustryLevyConne
     }
   }
 
-  private def getSdilReturn(retrievedSubscription: RetrievedSubscription,
+  def getSdilReturn(retrievedSubscription: RetrievedSubscription,
                             selectedReturnPeriod: ReturnPeriod)
                            (implicit hc: HeaderCarrier, ec: ExecutionContext): VariationResult[SdilReturn] = EitherT {
     connector.getReturn(retrievedSubscription.utr, selectedReturnPeriod).value.map {
@@ -87,4 +88,13 @@ class CorrectReturnOrchestrator @Inject()(connector: SoftDrinksIndustryLevyConne
       }
   }
 
+  private def generateUAsWithSavedSdilReturn(userAnswers: UserAnswers, sdilReturn: SdilReturn)
+                                               (implicit ec: ExecutionContext): VariationResult[UserAnswers] = EitherT {
+    Future.fromTry(userAnswers
+      .setOriginalSDILReturn(sdilReturn)
+    ).map(Right(_))
+      .recover {
+        case _ => Left(FailedToAddDataToUserAnswers)
+      }
+  }
 }

--- a/app/orchestrators/CorrectReturnOrchestrator.scala
+++ b/app/orchestrators/CorrectReturnOrchestrator.scala
@@ -48,8 +48,8 @@ class CorrectReturnOrchestrator @Inject()(connector: SoftDrinksIndustryLevyConne
 
     for {
       sdilReturn <- getSdilReturn(retrievedSubscription, selectedReturnPeriod)
-      updatedUserAnswersWithSavedSdilReturn <- generateUAsWithSavedSdilReturn(userAnswers, sdilReturn)
-      updatedUserAnswers <- generateUserAnswersWithSdilReturn(updatedUserAnswersWithSavedSdilReturn, sdilReturn, selectedReturnPeriod)
+      userAnswersWithOriginalSdilReturn <- generateUAsWithOriginalSdilReturnSaved(userAnswers, sdilReturn)
+      updatedUserAnswers <- generateUserAnswersWithSdilReturn(userAnswersWithOriginalSdilReturn, sdilReturn, selectedReturnPeriod)
       _ <- EitherT(sessionService.set(updatedUserAnswers))
     } yield (): Unit
 
@@ -88,7 +88,7 @@ class CorrectReturnOrchestrator @Inject()(connector: SoftDrinksIndustryLevyConne
       }
   }
 
-  private def generateUAsWithSavedSdilReturn(userAnswers: UserAnswers, sdilReturn: SdilReturn)
+  private def generateUAsWithOriginalSdilReturnSaved(userAnswers: UserAnswers, sdilReturn: SdilReturn)
                                                (implicit ec: ExecutionContext): VariationResult[UserAnswers] = EitherT {
     Future.fromTry(userAnswers
       .setOriginalSDILReturn(sdilReturn)

--- a/app/utilities/UserTypeCheck.scala
+++ b/app/utilities/UserTypeCheck.scala
@@ -21,7 +21,7 @@ import models.{RetrievedSubscription, SdilReturn}
 
 object UserTypeCheck {
   def isNewImporter(sdilReturn: SdilReturn,subscription: RetrievedSubscription): Boolean = {
-  (sdilReturn.totalImported._1 > 0L && sdilReturn.totalImported._2 > 0L) && !subscription.activity.importer && subscription.warehouseSites.isEmpty
+  (sdilReturn.totalImported._1 > 0L && sdilReturn.totalImported._2 > 0L) && !subscription.activity.importer
 }
   def isNewPacker(sdilReturn: SdilReturn, subscription: RetrievedSubscription): Boolean = {
     (sdilReturn.totalPacked._1 > 0L && sdilReturn.totalPacked._2 > 0L) && !subscription.activity.contractPacker

--- a/app/views/correctReturn/CorrectReturnCYAView.scala.html
+++ b/app/views/correctReturn/CorrectReturnCYAView.scala.html
@@ -26,7 +26,7 @@
 @layout(pageTitle = titleNoForm(messages("correctReturn.checkYourAnswers.title"))) {
 
     <h1 class="govuk-heading-l">@messages("correctReturn.checkYourAnswers.title")</h1>
-    <span class="govuk-body">@messages("correctReturn.checkChanges.updateFor")@orgName</span>
+    <span class="govuk-body">@messages("correctReturn.checkYourAnswers.updateFor")@orgName</span>
 
     @for((heading, summaryList) <- seqSummaryList) {
         <h2 class="govuk-heading-m">@messages(heading)</h2>

--- a/app/views/correctReturn/CorrectReturnCheckChangesCYAView.scala.html
+++ b/app/views/correctReturn/CorrectReturnCheckChangesCYAView.scala.html
@@ -34,6 +34,8 @@
     @govukSummaryList(summaryList)
     }
 
+    <p class="govuk-body">@messages("correctReturn.checkChanges.confirmationStatement")</p>
+
     @formHelper(action = submitCall, Symbol("autoComplete") -> "off") {
         @govukButton(ButtonViewModel(messages("correctReturn.checkChanges.confirmAndSend")))
     }

--- a/app/views/summary/UKSitesSummary.scala
+++ b/app/views/summary/UKSitesSummary.scala
@@ -91,20 +91,26 @@ object UKSitesSummary {
       )
   }
 
-  def getHeadingAndSummary(userAnswers: UserAnswers, isCheckAnswers: Boolean, subscription: RetrievedSubscription)
-                          (implicit messages: Messages): Option[(String, SummaryList)] = {
+  def getHeadingAndSummaryForCorrectReturn(userAnswers: UserAnswers, isCheckAnswers: Boolean, subscription: RetrievedSubscription)
+                                          (implicit messages: Messages): Option[(String, SummaryList)] = {
     val optSummaryList = (
       UserTypeCheck.isNewPacker(SdilReturn.apply(userAnswers), subscription),
-      UserTypeCheck.isNewImporter(SdilReturn.apply(userAnswers), subscription)
+      UserTypeCheck.isNewImporter(SdilReturn.apply(userAnswers), subscription),
+      subscription.productionSites.isEmpty,
+      subscription.warehouseSites.isEmpty
     ) match {
-      case (true, false) => Option(
+      case (true, false, true, _) =>
+        println(Console.YELLOW + "New packer, subscription list empty" + Console.WHITE)
+        Option(
         SummaryListViewModel(
           Seq(
             getPackAtBusinessAddressRow(userAnswers, isCheckAnswers)
           )
         )
       )
-      case (true, true) => Option(
+      case (true, true, true, true) =>
+        println(Console.YELLOW + "New packer & importer, subscription lists empty" + Console.WHITE)
+        Option(
         SummaryListViewModel(
           Seq(
             getPackAtBusinessAddressRow(userAnswers, isCheckAnswers),
@@ -112,7 +118,10 @@ object UKSitesSummary {
           )
         )
       )
-      case (false, true) => Option(
+      case (false, true, _, true) =>
+        println(Console.YELLOW + "New importer, subscription list empty" + Console.WHITE)
+        println(Console.YELLOW + "subscription is " + subscription + Console.WHITE)
+        Option(
         SummaryListViewModel(
           Seq(
             getAskSecondaryWarehouseRow(userAnswers, isCheckAnswers)

--- a/app/views/summary/UKSitesSummary.scala
+++ b/app/views/summary/UKSitesSummary.scala
@@ -91,22 +91,27 @@ object UKSitesSummary {
       )
   }
 
-  def getHeadingAndSummaryForCorrectReturn(userAnswers: UserAnswers, isCheckAnswers: Boolean, subscription: RetrievedSubscription)
-                                          (implicit messages: Messages): Option[(String, SummaryList)] = {
+  def getHeadingAndSummary(userAnswers: UserAnswers, isCheckAnswers: Boolean, subscription: RetrievedSubscription)
+                          (implicit messages: Messages): Option[(String, SummaryList)] = {
     val optSummaryList = (
-      UserTypeCheck.isNewPacker(SdilReturn.apply(userAnswers), subscription),
-      UserTypeCheck.isNewImporter(SdilReturn.apply(userAnswers), subscription),
-      subscription.productionSites.isEmpty,
-      subscription.warehouseSites.isEmpty
+      userAnswers.packagingSiteList.nonEmpty,
+      userAnswers.warehouseList.nonEmpty
     ) match {
-      case (true, false, true, _) => Option(
+      case (true, false) => Option(
         SummaryListViewModel(
           Seq(
             getPackAtBusinessAddressRow(userAnswers, isCheckAnswers)
           )
         )
       )
-      case (true, true, true, true) => Option(
+      case (false, true) => Option(
+        SummaryListViewModel(
+          Seq(
+            getAskSecondaryWarehouseRow(userAnswers, isCheckAnswers)
+          )
+        )
+      )
+      case (true, true) => Option(
         SummaryListViewModel(
           Seq(
             getPackAtBusinessAddressRow(userAnswers, isCheckAnswers),
@@ -114,9 +119,35 @@ object UKSitesSummary {
           )
         )
       )
-      case (false, true, _, true) => Option(
+      case _ => None
+    }
+    optSummaryList.map(list => "checkYourAnswers.sites" -> list)
+  }
+
+  def getHeadingAndSummaryForCorrectReturn(userAnswers: UserAnswers, isCheckAnswers: Boolean, subscription: RetrievedSubscription)
+                                          (implicit messages: Messages): Option[(String, SummaryList)] = {
+    val optSummaryList = (
+      UserTypeCheck.isNewPacker(SdilReturn.apply(userAnswers), subscription) && subscription.productionSites.isEmpty,
+      UserTypeCheck.isNewImporter(SdilReturn.apply(userAnswers), subscription) && subscription.warehouseSites.isEmpty
+    ) match {
+      case (true, false) => Option(
         SummaryListViewModel(
           Seq(
+            getPackAtBusinessAddressRow(userAnswers, isCheckAnswers)
+          )
+        )
+      )
+      case (false, true) => Option(
+        SummaryListViewModel(
+          Seq(
+            getAskSecondaryWarehouseRow(userAnswers, isCheckAnswers)
+          )
+        )
+      )
+      case (true, true) => Option(
+        SummaryListViewModel(
+          Seq(
+            getPackAtBusinessAddressRow(userAnswers, isCheckAnswers),
             getAskSecondaryWarehouseRow(userAnswers, isCheckAnswers)
           )
         )

--- a/app/views/summary/UKSitesSummary.scala
+++ b/app/views/summary/UKSitesSummary.scala
@@ -99,18 +99,14 @@ object UKSitesSummary {
       subscription.productionSites.isEmpty,
       subscription.warehouseSites.isEmpty
     ) match {
-      case (true, false, true, _) =>
-        println(Console.YELLOW + "New packer, subscription list empty" + Console.WHITE)
-        Option(
+      case (true, false, true, _) => Option(
         SummaryListViewModel(
           Seq(
             getPackAtBusinessAddressRow(userAnswers, isCheckAnswers)
           )
         )
       )
-      case (true, true, true, true) =>
-        println(Console.YELLOW + "New packer & importer, subscription lists empty" + Console.WHITE)
-        Option(
+      case (true, true, true, true) => Option(
         SummaryListViewModel(
           Seq(
             getPackAtBusinessAddressRow(userAnswers, isCheckAnswers),
@@ -118,10 +114,7 @@ object UKSitesSummary {
           )
         )
       )
-      case (false, true, _, true) =>
-        println(Console.YELLOW + "New importer, subscription list empty" + Console.WHITE)
-        println(Console.YELLOW + "subscription is " + subscription + Console.WHITE)
-        Option(
+      case (false, true, _, true) => Option(
         SummaryListViewModel(
           Seq(
             getAskSecondaryWarehouseRow(userAnswers, isCheckAnswers)

--- a/app/views/summary/correctReturn/CorrectReturnBaseCYASummary.scala
+++ b/app/views/summary/correctReturn/CorrectReturnBaseCYASummary.scala
@@ -17,6 +17,7 @@
 package views.summary.correctReturn
 
 import config.FrontendAppConfig
+import models.correctReturn.ChangedPage
 import models.{RetrievedSubscription, UserAnswers}
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.SummaryList
@@ -33,8 +34,21 @@ object CorrectReturnBaseCYASummary {
       claimCreditsForLostDamagedSection(userAnswers) ++ siteDetailsSection(userAnswers, subscription)).toSeq
   }
 
-  def ownBrandsSummarySection(userAnswers: UserAnswers)
-                                  (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
+  def changedSummaryListAndHeadings(userAnswers: UserAnswers, subscription: RetrievedSubscription, changedPages: List[ChangedPage])
+                            (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Seq[(String, SummaryList)] = {
+    (ownBrandsSummarySection(userAnswers, changedPages.head.answerChanged) ++
+      contractPackerSummarySection(userAnswers, changedPages.apply(2).answerChanged) ++
+      contractPackedForRegisteredSmallProducersSection(userAnswers, changedPages.apply(12).answerChanged) ++
+      broughtIntoUKSection(userAnswers, changedPages.apply(4).answerChanged) ++
+      broughtIntoUkFromSmallProducersSection(userAnswers, changedPages.apply(6).answerChanged) ++
+      claimCreditsForExportsSection(userAnswers, changedPages.apply(8).answerChanged) ++
+      claimCreditsForLostDamagedSection(userAnswers, changedPages.apply(10).answerChanged) ++
+      siteDetailsSection(userAnswers, subscription)
+      ).toSeq
+  }
+
+  private def ownBrandsSummarySection(userAnswers: UserAnswers, changedPage: Boolean = true)
+                                     (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
     val ownBrandsSummary: SummaryList = OperatePackagingSiteOwnBrandsSummary.summaryList(userAnswers, isCheckAnswers = true)
     val ownBrandsSummaryList: Option[(String, SummaryList)] = if (ownBrandsSummary.rows.isEmpty) None else {
       Option(
@@ -42,10 +56,15 @@ object CorrectReturnBaseCYASummary {
           ownBrandsSummary
       )
     }
-    ownBrandsSummaryList
+    val showOwnBrandsSummaryList: Option[(String, SummaryList)] = if (changedPage) {
+      ownBrandsSummaryList
+    } else {
+      None
+    }
+    showOwnBrandsSummaryList
   }
-  def contractPackerSummarySection(userAnswers: UserAnswers)
-                                  (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
+  private def contractPackerSummarySection(userAnswers: UserAnswers, changedPage: Boolean = true)
+                                          (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
     val contractPackedOwnSiteSummary: SummaryList = PackagedAsContractPackerSummary.summaryList(userAnswers, isCheckAnswers = true)
     val contractPackedOwnSiteList: Option[(String, SummaryList)] = if (contractPackedOwnSiteSummary.rows.isEmpty) None else {
       Option(
@@ -53,11 +72,17 @@ object CorrectReturnBaseCYASummary {
           contractPackedOwnSiteSummary
       )
     }
-    contractPackedOwnSiteList
+    val showContractPackedOwnSiteList: Option[(String, SummaryList)] = if (changedPage) {
+      contractPackedOwnSiteList
+    } else {
+      None
+    }
+    showContractPackedOwnSiteList
   }
 
-  def contractPackedForRegisteredSmallProducersSection(userAnswers: UserAnswers)
-                                                      (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
+  private def contractPackedForRegisteredSmallProducersSection(userAnswers: UserAnswers, changedPage: Boolean = true)
+                                                              (implicit messages: Messages, frontendAppConfig: FrontendAppConfig)
+  : Option[(String, SummaryList)] = {
     val contractPackedForRegisteredSmallProducers: SummaryList =
       ExemptionsForSmallProducersSummary.summaryList(userAnswers, isCheckAnswers = true)
     val contractPackedForRegisteredSmallProducersList: Option[(String, SummaryList)] = {
@@ -68,11 +93,16 @@ object CorrectReturnBaseCYASummary {
         )
       }
     }
-    contractPackedForRegisteredSmallProducersList
+    val showContractPackedForRegisteredSmallProducersList: Option[(String, SummaryList)] = if (changedPage) {
+      contractPackedForRegisteredSmallProducersList
+    } else {
+      None
+    }
+    showContractPackedForRegisteredSmallProducersList
   }
 
-  def broughtIntoUKSection(userAnswers: UserAnswers)
-                          (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
+  private def broughtIntoUKSection(userAnswers: UserAnswers, changedPage: Boolean = true)
+                                  (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
     val broughtIntoUKSummary: SummaryList = BroughtIntoUKSummary.summaryList(userAnswers, isCheckAnswers = true)
     val broughtIntoUKList: Option[(String, SummaryList)] = if (broughtIntoUKSummary.rows.isEmpty) None else {
       Option(
@@ -80,26 +110,36 @@ object CorrectReturnBaseCYASummary {
           broughtIntoUKSummary
       )
     }
-    broughtIntoUKList
-  }
-
-  def broughtIntoUkFromSmallProducersSection(userAnswers: UserAnswers)
-                                            (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
-  val broughtIntoUkFromSmallProducersSummary: SummaryList =
-    BroughtIntoUkFromSmallProducersSummary.summaryList(userAnswers, isCheckAnswers = true)
-  val broughtIntoUkFromSmallProducersList: Option[(String, SummaryList)] = {
-    if (broughtIntoUkFromSmallProducersSummary.rows.isEmpty) None else {
-      Option(
-        "correctReturn.broughtIntoUkFromSmallProducers.checkYourAnswersSectionHeader" ->
-          broughtIntoUkFromSmallProducersSummary
-      )
+    val showBroughtIntoUKList: Option[(String, SummaryList)] = if (changedPage) {
+      broughtIntoUKList
+    } else {
+      None
     }
-  }
-    broughtIntoUkFromSmallProducersList
+    showBroughtIntoUKList
   }
 
-  def claimCreditsForExportsSection(userAnswers: UserAnswers)
-                                            (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
+  private def broughtIntoUkFromSmallProducersSection(userAnswers: UserAnswers, changedPage: Boolean = true)
+                                                    (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
+    val broughtIntoUkFromSmallProducersSummary: SummaryList =
+      BroughtIntoUkFromSmallProducersSummary.summaryList(userAnswers, isCheckAnswers = true)
+    val broughtIntoUkFromSmallProducersList: Option[(String, SummaryList)] = {
+      if (broughtIntoUkFromSmallProducersSummary.rows.isEmpty) None else {
+        Option(
+          "correctReturn.broughtIntoUkFromSmallProducers.checkYourAnswersSectionHeader" ->
+            broughtIntoUkFromSmallProducersSummary
+        )
+      }
+    }
+    val showBroughtIntoUkFromSmallProducersList: Option[(String, SummaryList)] = if (changedPage) {
+      broughtIntoUkFromSmallProducersList
+    } else {
+      None
+    }
+    showBroughtIntoUkFromSmallProducersList
+  }
+
+  private def claimCreditsForExportsSection(userAnswers: UserAnswers, changedPage: Boolean = true)
+                                           (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
     val claimCreditsForExportsSummary: SummaryList = ClaimCreditsForExportsSummary.summaryList(userAnswers, isCheckAnswers = true)
     val claimCreditsForExportsList: Option[(String, SummaryList)] = if (claimCreditsForExportsSummary.rows.isEmpty) None else {
       Option(
@@ -107,11 +147,16 @@ object CorrectReturnBaseCYASummary {
           claimCreditsForExportsSummary
       )
     }
-    claimCreditsForExportsList
+    val showClaimCreditsForExportsList: Option[(String, SummaryList)] = if (changedPage) {
+      claimCreditsForExportsList
+    } else {
+      None
+    }
+    showClaimCreditsForExportsList
   }
 
-  def claimCreditsForLostDamagedSection(userAnswers: UserAnswers)
-                                   (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
+  private def claimCreditsForLostDamagedSection(userAnswers: UserAnswers, changedPage: Boolean = true)
+                                               (implicit messages: Messages, frontendAppConfig: FrontendAppConfig): Option[(String, SummaryList)] = {
     val claimCreditsForLostDamagedSummary: SummaryList = ClaimCreditsForLostDestroyedSummary.summaryList(userAnswers, isCheckAnswers = true)
     val claimCreditsForLostDamagedList: Option[(String, SummaryList)] = if (claimCreditsForLostDamagedSummary.rows.isEmpty) None else {
       Option(
@@ -119,10 +164,15 @@ object CorrectReturnBaseCYASummary {
           claimCreditsForLostDamagedSummary
       )
     }
-    claimCreditsForLostDamagedList
+    val showClaimCreditsForLostDamagedList: Option[(String, SummaryList)] = if (changedPage) {
+      claimCreditsForLostDamagedList
+    } else {
+      None
+    }
+    showClaimCreditsForLostDamagedList
   }
 
-  def siteDetailsSection(userAnswers: UserAnswers, subscription: RetrievedSubscription)(implicit messages: Messages): Option[(String, SummaryList)] =
-    UKSitesSummary.getHeadingAndSummary(userAnswers, isCheckAnswers = true, subscription)
+  private def siteDetailsSection(userAnswers: UserAnswers, subscription: RetrievedSubscription)(implicit messages: Messages): Option[(String, SummaryList)] =
+    UKSitesSummary.getHeadingAndSummaryForCorrectReturn(userAnswers, isCheckAnswers = true, subscription)
 
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -503,8 +503,11 @@ correctReturn.askSecondaryWarehouseInReturn.detailsLink = Why should I register 
 correctReturn.askSecondaryWarehouseInReturn.detailsContent1 = You can delay when you have to report liable drinks in your quarterly return and pay the levy on them if you register the warehouses you use to store them.
 correctReturn.askSecondaryWarehouseInReturn.detailsContent2 = Because you changed your business activity, you can choose to register any of the UK warehouses you use to store liable drinks.
 
-correctReturn.checkYourAnswers.updateFor = This update is for
-correctReturn.checkYourAnswers.title = Check your answers before sending your update
+correctReturn.checkChanges.updateFor = This update is for
+correctReturn.checkChanges.title = Check your answers before sending your correction
+correctReturn.checkChanges.confirmationStatement = By sending this correction you are confirming that, to the best of your knowledge, the details you are providing are correct.
+correctReturn.checkChanges.balanceHeader = Balance
+correctReturn.checkChanges.sendReturnHeader = Send your return
 
 correctReturn.checkChanges.updateFor = This update is for
 correctReturn.checkChanges.title = Check your answers before sending your correction

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -508,11 +508,12 @@ correctReturn.checkChanges.title = Check your answers before sending your correc
 correctReturn.checkChanges.confirmationStatement = By sending this correction you are confirming that, to the best of your knowledge, the details you are providing are correct.
 correctReturn.checkChanges.balanceHeader = Balance
 correctReturn.checkChanges.sendReturnHeader = Send your return
-
-correctReturn.checkChanges.updateFor = This update is for
-correctReturn.checkChanges.title = Check your answers before sending your correction
-
 correctReturn.checkChanges.confirmAndSend = Confirm details and send correction
+
+correctReturn.checkYourAnswers.updateFor = This update is for
+correctReturn.checkYourAnswers.title = Check your answers before sending your update
+
+
 
 
 updateRegisteredDetails.contactDetails.title = Change person''s details

--- a/it/controllers/CorrectReturnBaseCYASummaryISpecHelper.scala
+++ b/it/controllers/CorrectReturnBaseCYASummaryISpecHelper.scala
@@ -19,11 +19,10 @@ package controllers
 import controllers.correctReturn.routes
 import models.correctReturn.AddASmallProducer
 import models.{CheckMode, LitresInBands, SdilReturn, UserAnswers}
-import org.bson.json.JsonObject
 import org.jsoup.nodes.Element
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
-import pages.{Page, QuestionPage}
+import pages.QuestionPage
 import pages.correctReturn._
 import play.api.libs.json.Json
 import testSupport.SDILBackendTestData.{smallProducerList, submittedDateTime}
@@ -82,6 +81,7 @@ trait CorrectReturnBaseCYASummaryISpecHelper extends ControllerITTestHelper {
   def userAnswerWithExemptionSmallProducerPageUpdatedAndNilSdilReturn: UserAnswers = emptyUserAnswersForCorrectReturnWithWarehouses
     .copy(data = Json.obj("originalSDILReturn" -> Json.toJson(emptyReturn)))
     .copy(smallProducerList = smallProducersAddedList)
+    .set(ExemptionsForSmallProducersPage, true).success.value
     .set(AddASmallProducerPage, AddASmallProducer(None, "XZSDIL000000234", smallProducerLitres)).success.value
 
   def userAnswerWithAllNosWithOriginalSdilReturn: UserAnswers = emptyUserAnswersForCorrectReturnWithWarehouses

--- a/it/controllers/CorrectReturnBaseCYASummaryISpecHelper.scala
+++ b/it/controllers/CorrectReturnBaseCYASummaryISpecHelper.scala
@@ -51,7 +51,7 @@ trait CorrectReturnBaseCYASummaryISpecHelper extends ControllerITTestHelper {
     smallProducerList, (300, 400), (400, 300), (50, 60), (60, 50),
     submittedOn = Some(submittedDateTime.toInstant(ZoneOffset.UTC)))
 
-  def userAnswerWithLitresForAllPagesNilSdilReturn: UserAnswers = emptyUserAnswersForCorrectReturnWithWarehouses
+  def userAnswerWithLitresForAllPagesNilSdilReturn: UserAnswers = emptyUserAnswersForCorrectReturn
     .copy(data = Json.obj("originalSDILReturn" -> Json.toJson(emptyReturn)))
     .copy(smallProducerList = smallProducersAddedList)
     .set(OperatePackagingSiteOwnBrandsPage, true).success.value
@@ -73,18 +73,18 @@ trait CorrectReturnBaseCYASummaryISpecHelper extends ControllerITTestHelper {
     .set(AskSecondaryWarehouseInReturnPage, true).success.value
     .set(SecondaryWarehouseDetailsPage, false).success.value
 
-  def userAnswerWithOnePageChangedAndNilSdilReturn(page: QuestionPage[Boolean], howManyPage: QuestionPage[LitresInBands]): UserAnswers = emptyUserAnswersForCorrectReturnWithWarehouses
+  def userAnswerWithOnePageChangedAndNilSdilReturn(page: QuestionPage[Boolean], howManyPage: QuestionPage[LitresInBands]): UserAnswers = emptyUserAnswersForCorrectReturn
     .copy(data = Json.obj("originalSDILReturn" -> Json.toJson(emptyReturn)))
     .set(page, true).success.value
     .set(howManyPage, operatePackagingSiteLitres).success.value
 
-  def userAnswerWithExemptionSmallProducerPageUpdatedAndNilSdilReturn: UserAnswers = emptyUserAnswersForCorrectReturnWithWarehouses
+  def userAnswerWithExemptionSmallProducerPageUpdatedAndNilSdilReturn: UserAnswers = emptyUserAnswersForCorrectReturn
     .copy(data = Json.obj("originalSDILReturn" -> Json.toJson(emptyReturn)))
     .copy(smallProducerList = smallProducersAddedList)
     .set(ExemptionsForSmallProducersPage, true).success.value
     .set(AddASmallProducerPage, AddASmallProducer(None, "XZSDIL000000234", smallProducerLitres)).success.value
 
-  def userAnswerWithAllNosWithOriginalSdilReturn: UserAnswers = emptyUserAnswersForCorrectReturnWithWarehouses
+  def userAnswerWithAllNosWithOriginalSdilReturn: UserAnswers = emptyUserAnswersForCorrectReturn
       .copy(data = Json.obj("originalSDILReturn" -> Json.toJson(populatedReturn)))
       .set(OperatePackagingSiteOwnBrandsPage, false).success.value
       .set(PackagedAsContractPackerPage, false).success.value

--- a/it/controllers/correctReturn/CorrectReturnCYAControllerISpec.scala
+++ b/it/controllers/correctReturn/CorrectReturnCYAControllerISpec.scala
@@ -35,7 +35,7 @@ class CorrectReturnCYAControllerISpec extends CorrectReturnBaseCYASummaryISpecHe
 
     "when the user has populated all pages including litres" - {
       "should render the check your answers page with only the required details" in {
-        val userAnswers = userAnswerWithLitresForAllPages
+        val userAnswers = userAnswerWithLitresForAllPagesNilSdilReturn
         given
           .commonPrecondition
 
@@ -98,7 +98,7 @@ class CorrectReturnCYAControllerISpec extends CorrectReturnBaseCYASummaryISpecHe
 
       "and they have only populated the required pages and have no litres" - {
         "should render the check your answers page with expected summary items" in {
-          val userAnswers = userAnswerWithAllNos
+          val userAnswers = userAnswerWithAllNosWithOriginalSdilReturn
           given
             .commonPrecondition
 
@@ -153,30 +153,6 @@ class CorrectReturnCYAControllerISpec extends CorrectReturnBaseCYASummaryISpecHe
           }
         }
       }
-
-//      "and the user answers are no to own brands and yes to co-pack and import " +
-//        "then sites should be displayed" in {
-//        val userAnswers = userAnswerWithLitresForAllPages(Large)
-//          .set(OperatePackagingSitesPage, false).success.value
-//          .remove(HowManyOperatePackagingSitesPage).success.value
-//
-//        given
-//          .commonPrecondition
-//
-//        setAnswers(userAnswers)
-//
-//        WsTestClient.withClient { client =>
-//          val result = createClientRequestGet(client, baseUrl + route)
-//
-//          whenReady(result) { res =>
-//            res.status mustBe OK
-//            val page = Jsoup.parse(res.body)
-//            page.getElementsByTag("dt").text() must include("You have 3 packaging sites")
-//
-//          }
-//        }
-//      }
-
     }
 
     testUnauthorisedUser(baseUrl + route)

--- a/it/controllers/correctReturn/CorrectReturnCYAControllerISpec.scala
+++ b/it/controllers/correctReturn/CorrectReturnCYAControllerISpec.scala
@@ -1,9 +1,11 @@
 package controllers.correctReturn
 
+import testSupport.SDILBackendTestData.aSubscription
 import controllers.CorrectReturnBaseCYASummaryISpecHelper
 import models.SelectChange.CorrectReturn
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import pages.correctReturn.PackAtBusinessAddressPage
 import play.api.http.HeaderNames
 import play.api.http.Status.OK
 import play.api.libs.json.Json
@@ -35,9 +37,11 @@ class CorrectReturnCYAControllerISpec extends CorrectReturnBaseCYASummaryISpecHe
 
     "when the user has populated all pages including litres" - {
       "should render the check your answers page with only the required details" in {
-        val userAnswers = userAnswerWithLitresForAllPagesNilSdilReturn.copy(warehouseList = warehousesFromSubscription)
+        val userAnswers = userAnswerWithLitresForAllPagesNilSdilReturn
+          .copy(packagingSiteList = packagingSitesFromSubscription, warehouseList = warehousesFromSubscription)
+          .set(PackAtBusinessAddressPage, true).success.value
         given
-          .commonPreconditionChangeSubscription(diffSubscription)
+          .commonPrecondition
 
         setAnswers(userAnswers)
 
@@ -88,7 +92,7 @@ class CorrectReturnCYAControllerISpec extends CorrectReturnBaseCYASummaryISpecHe
             val siteDetailsSummaryListItem = page.getElementsByClass("govuk-summary-list").get(7)
 
             page.getElementsByTag("h2").get(7).text() mustBe "UK site details"
-            validateSiteDetailsSummary(siteDetailsSummaryListItem, 1, 2, true)
+            validateSiteDetailsSummary(userAnswers, aSubscription, siteDetailsSummaryListItem, 1, 2, true)
 
             page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCYAController.onSubmit.url
             page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Save and continue"

--- a/it/controllers/correctReturn/CorrectReturnCYAControllerISpec.scala
+++ b/it/controllers/correctReturn/CorrectReturnCYAControllerISpec.scala
@@ -35,9 +35,9 @@ class CorrectReturnCYAControllerISpec extends CorrectReturnBaseCYASummaryISpecHe
 
     "when the user has populated all pages including litres" - {
       "should render the check your answers page with only the required details" in {
-        val userAnswers = userAnswerWithLitresForAllPagesNilSdilReturn
+        val userAnswers = userAnswerWithLitresForAllPagesNilSdilReturn.copy(warehouseList = warehousesFromSubscription)
         given
-          .commonPrecondition
+          .commonPreconditionChangeSubscription(diffSubscription)
 
         setAnswers(userAnswers)
 

--- a/it/controllers/correctReturn/CorrectReturnCheckChangesCYAControllerISpec.scala
+++ b/it/controllers/correctReturn/CorrectReturnCheckChangesCYAControllerISpec.scala
@@ -29,6 +29,7 @@ class CorrectReturnCheckChangesCYAControllerISpec extends ControllerITTestHelper
             val page = Jsoup.parse(res.body)
             page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
             page.getElementsByClass("govuk-summary-list").size() mustBe 0
+            page.getElementsByClass("govuk-body").size() mustBe 2
           }
         }
       }

--- a/it/controllers/correctReturn/CorrectReturnCheckChangesCYAControllerISpec.scala
+++ b/it/controllers/correctReturn/CorrectReturnCheckChangesCYAControllerISpec.scala
@@ -1,21 +1,23 @@
 package controllers.correctReturn
 
-import controllers.ControllerITTestHelper
+import controllers.CorrectReturnBaseCYASummaryISpecHelper
+import models.LitresInBands
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import pages.correctReturn.{BroughtIntoUKPage, BroughtIntoUkFromSmallProducersPage, ClaimCreditsForExportsPage, ClaimCreditsForLostDamagedPage, ExemptionsForSmallProducersPage, HowManyBroughtIntoUKPage, HowManyBroughtIntoUkFromSmallProducersPage, HowManyClaimCreditsForExportsPage, HowManyCreditsForLostDamagedPage, HowManyOperatePackagingSiteOwnBrandsPage, HowManyPackagedAsContractPackerPage, OperatePackagingSiteOwnBrandsPage, PackagedAsContractPackerPage}
 import play.api.http.Status.OK
 import play.api.libs.json.Json
 import play.api.test.WsTestClient
 import play.mvc.Http.HeaderNames
 
-class CorrectReturnCheckChangesCYAControllerISpec extends ControllerITTestHelper {
+class CorrectReturnCheckChangesCYAControllerISpec extends CorrectReturnBaseCYASummaryISpecHelper {
 
   val route = "/correct-return/check-changes"
 
   "GET " + routes.CorrectReturnCheckChangesCYAController.onPageLoad.url - {
 
     "when the userAnswers contains no data" - {
-      "should render the page" in {
+      "should result in a server error" in {
         given
           .commonPrecondition
 
@@ -25,11 +27,330 @@ class CorrectReturnCheckChangesCYAControllerISpec extends ControllerITTestHelper
           val result = createClientRequestGet(client, baseUrl + route)
 
           whenReady(result) { res =>
+            res.status mustBe 500
+          }
+        }
+      }
+    }
+
+    "when the user has changed all pages including litres" - {
+      "should render the check changes page with all sections" in {
+        val userAnswers = userAnswerWithLitresForAllPagesNilSdilReturn
+        given
+          .commonPrecondition
+
+        setAnswers(userAnswers)
+
+        WsTestClient.withClient { client =>
+          val result = createClientRequestGet(client, baseUrl + route)
+
+          whenReady(result) { res =>
             res.status mustBe OK
             val page = Jsoup.parse(res.body)
             page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
-            page.getElementsByClass("govuk-summary-list").size() mustBe 0
-            page.getElementsByClass("govuk-body").size() mustBe 2
+            page.getElementsByClass("govuk-summary-list").size() mustBe 7
+
+            val operatePackagingSites = page.getElementsByClass("govuk-summary-list").get(0)
+
+            page.getElementsByTag("h2").get(0).text() mustBe "Own brands packaged at your own site"
+            validateOperatePackagingSitesWithLitresSummaryList(operatePackagingSites, operatePackagingSiteLitres, true)
+
+            val contractPacking = page.getElementsByClass("govuk-summary-list").get(1)
+
+            page.getElementsByTag("h2").get(1).text() mustBe "Contract packed at your own site"
+            validateContractPackingWithLitresSummaryList(contractPacking, contractPackingLitres, true)
+
+            val contractPackedForSmallProducers = page.getElementsByClass("govuk-summary-list").get(2)
+
+            page.getElementsByTag("h2").get(2).text() mustBe "Contract packed for registered small producers"
+            validateContractPackedForSmallProducersWithLitresSummaryList(contractPackedForSmallProducers, smallProducerLitres, true)
+
+            val imports = page.getElementsByClass("govuk-summary-list").get(3)
+
+            page.getElementsByTag("h2").get(3).text() mustBe "Brought into the UK"
+            validateImportsWithLitresSummaryList(imports, importsLitres, true)
+
+            val importsSmallProducers = page.getElementsByClass("govuk-summary-list").get(4)
+
+            page.getElementsByTag("h2").get(4).text() mustBe "Brought into the UK from small producers"
+            validateImportsFromSmallProducersWithLitresSummaryList(importsSmallProducers, importsLitres, true)
+
+            val exported = page.getElementsByClass("govuk-summary-list").get(5)
+
+            page.getElementsByTag("h2").get(5).text() mustBe "Exported"
+            validateExportsWithLitresSummaryList(exported, importsLitres, true)
+
+            val lostOrDamaged = page.getElementsByClass("govuk-summary-list").get(6)
+
+            page.getElementsByTag("h2").get(6).text() mustBe "Lost or destroyed"
+            validateLostOrDamagedWithLitresSummaryList(lostOrDamaged, importsLitres, true)
+
+            page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
+            page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"
+          }
+        }
+      }
+
+      "and they have changed all answers to no and have no litres" - {
+        "should render the check changes page with all summary items" in {
+          val userAnswers = userAnswerWithAllNosWithOriginalSdilReturn
+          given
+            .commonPrecondition
+
+          setAnswers(userAnswers)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestGet(client, baseUrl + route)
+
+            whenReady(result) { res =>
+              res.status mustBe OK
+              val page = Jsoup.parse(res.body)
+              page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
+              page.getElementsByClass("govuk-summary-list").size() mustBe 7
+
+              val operatePackagingSites = page.getElementsByClass("govuk-summary-list").get(0)
+              page.getElementsByTag("h2").get(0).text() mustBe "Own brands packaged at your own site"
+              validateOperatePackagingSitesWithNoLitresSummaryList(operatePackagingSites, true)
+
+              val contractPacking = page.getElementsByClass("govuk-summary-list").get(1)
+
+              page.getElementsByTag("h2").get(1).text() mustBe "Contract packed at your own site"
+              validateContractPackingWithNoLitresSummaryList(contractPacking, true)
+
+              val contractPackedForSmallProducers = page.getElementsByClass("govuk-summary-list").get(2)
+
+              page.getElementsByTag("h2").get(2).text() mustBe "Contract packed for registered small producers"
+              validateContractPackedForSmallProducersWithNoLitresSummaryList(contractPackedForSmallProducers, true)
+
+              val imports = page.getElementsByClass("govuk-summary-list").get(3)
+
+              page.getElementsByTag("h2").get(3).text() mustBe "Brought into the UK"
+              validateImportsWithNoLitresSummaryList(imports, true)
+
+              val importsFromSmallProducers = page.getElementsByClass("govuk-summary-list").get(4)
+
+              page.getElementsByTag("h2").get(4).text() mustBe "Brought into the UK from small producers"
+              validateImportsFromSmallProducersWithNoLitresSummaryList(importsFromSmallProducers, true)
+
+              val exports = page.getElementsByClass("govuk-summary-list").get(5)
+
+              page.getElementsByTag("h2").get(5).text() mustBe "Exported"
+              validateExportsWithNoLitresSummaryList(exports, true)
+
+              val lostOrDamaged = page.getElementsByClass("govuk-summary-list").get(6)
+
+              page.getElementsByTag("h2").get(6).text() mustBe "Lost or destroyed"
+              validateLostOrDamagedWithNoLitresSummaryList(lostOrDamaged, true)
+
+              page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
+              page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"
+            }
+          }
+        }
+      }
+    }
+
+    "when the user has changed answers on select pages should render only the changed section(s)" - {
+      s"when the user has changed answers on $OperatePackagingSiteOwnBrandsPage" - {
+        "should render the check changes page with only the own brands section" in {
+          val userAnswers = userAnswerWithOnePageChangedAndNilSdilReturn(OperatePackagingSiteOwnBrandsPage, HowManyOperatePackagingSiteOwnBrandsPage)
+          given
+            .commonPrecondition
+
+          setAnswers(userAnswers)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestGet(client, baseUrl + route)
+
+            whenReady(result) { res =>
+              res.status mustBe OK
+              val page = Jsoup.parse(res.body)
+              page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
+              page.getElementsByClass("govuk-summary-list").size() mustBe 1
+
+              val operatePackagingSites = page.getElementsByClass("govuk-summary-list").get(0)
+
+              page.getElementsByTag("h2").get(0).text() mustBe "Own brands packaged at your own site"
+              validateOperatePackagingSitesWithLitresSummaryList(operatePackagingSites, LitresInBands(1000, 2000), true)
+
+              page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
+              page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"
+            }
+          }
+        }
+      }
+
+      s"when the user has changed answers on $PackagedAsContractPackerPage" - {
+        "should render the check changes page with only the packaged as contract packer section" in {
+          val userAnswers = userAnswerWithOnePageChangedAndNilSdilReturn(PackagedAsContractPackerPage, HowManyPackagedAsContractPackerPage)
+          given
+            .commonPrecondition
+
+          setAnswers(userAnswers)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestGet(client, baseUrl + route)
+
+            whenReady(result) { res =>
+              res.status mustBe OK
+              val page = Jsoup.parse(res.body)
+              page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
+              page.getElementsByClass("govuk-summary-list").size() mustBe 1
+
+              val contractPacking = page.getElementsByClass("govuk-summary-list").get(0)
+
+              page.getElementsByTag("h2").get(0).text() mustBe "Contract packed at your own site"
+              validateContractPackingWithLitresSummaryList(contractPacking, LitresInBands(1000, 2000), true)
+
+              page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
+              page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"
+            }
+          }
+        }
+      }
+
+      s"when the user has changed answers on $BroughtIntoUKPage" - {
+        "should render the check changes page with only the Brought into the UK section" in {
+          val userAnswers = userAnswerWithOnePageChangedAndNilSdilReturn(BroughtIntoUKPage, HowManyBroughtIntoUKPage)
+          given
+            .commonPrecondition
+
+          setAnswers(userAnswers)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestGet(client, baseUrl + route)
+
+            whenReady(result) { res =>
+              res.status mustBe OK
+
+              val page = Jsoup.parse(res.body)
+              page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
+              page.getElementsByClass("govuk-summary-list").size() mustBe 1
+
+              val contractPacking = page.getElementsByClass("govuk-summary-list").get(0)
+
+              page.getElementsByTag("h2").get(0).text() mustBe "Brought into the UK"
+              validateImportsWithLitresSummaryList(contractPacking, LitresInBands(1000, 2000), true)
+
+              page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
+              page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"
+            }
+          }
+        }
+      }
+
+      s"when the user has changed answers on $BroughtIntoUkFromSmallProducersPage" - {
+        "should render the check changes page with only the Brought into the UK from small producers section" in {
+          val userAnswers = userAnswerWithOnePageChangedAndNilSdilReturn(BroughtIntoUkFromSmallProducersPage, HowManyBroughtIntoUkFromSmallProducersPage)
+          given
+            .commonPrecondition
+
+          setAnswers(userAnswers)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestGet(client, baseUrl + route)
+
+            whenReady(result) { res =>
+              res.status mustBe OK
+              val page = Jsoup.parse(res.body)
+              page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
+              page.getElementsByClass("govuk-summary-list").size() mustBe 1
+
+              val contractPacking = page.getElementsByClass("govuk-summary-list").get(0)
+
+              page.getElementsByTag("h2").get(0).text() mustBe "Brought into the UK from small producers"
+              validateImportsFromSmallProducersWithLitresSummaryList(contractPacking, LitresInBands(1000, 2000), true)
+
+              page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
+              page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"
+            }
+          }
+        }
+      }
+
+      s"when the user has changed answers on $ClaimCreditsForExportsPage" - {
+        "should render the check changes page with only the Exports section" in {
+          val userAnswers = userAnswerWithOnePageChangedAndNilSdilReturn(ClaimCreditsForExportsPage, HowManyClaimCreditsForExportsPage)
+          given
+            .commonPrecondition
+
+          setAnswers(userAnswers)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestGet(client, baseUrl + route)
+
+            whenReady(result) { res =>
+              res.status mustBe OK
+              val page = Jsoup.parse(res.body)
+              page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
+              page.getElementsByClass("govuk-summary-list").size() mustBe 1
+
+              val contractPacking = page.getElementsByClass("govuk-summary-list").get(0)
+
+              page.getElementsByTag("h2").get(0).text() mustBe "Exported"
+              validateExportsWithLitresSummaryList(contractPacking, LitresInBands(1000, 2000), true)
+
+              page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
+              page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"
+            }
+          }
+        }
+      }
+
+      s"when the user has changed answers on $ClaimCreditsForLostDamagedPage" - {
+        "should render the check changes page with only the Lost Destroyed section" in {
+          val userAnswers = userAnswerWithOnePageChangedAndNilSdilReturn(ClaimCreditsForLostDamagedPage, HowManyCreditsForLostDamagedPage)
+          given
+            .commonPrecondition
+
+          setAnswers(userAnswers)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestGet(client, baseUrl + route)
+
+            whenReady(result) { res =>
+              res.status mustBe OK
+              val page = Jsoup.parse(res.body)
+              page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
+              page.getElementsByClass("govuk-summary-list").size() mustBe 1
+
+              val contractPacking = page.getElementsByClass("govuk-summary-list").get(0)
+
+              page.getElementsByTag("h2").get(0).text() mustBe "Lost or destroyed"
+              validateLostOrDamagedWithLitresSummaryList(contractPacking, LitresInBands(1000, 2000), true)
+
+              page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
+              page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"
+            }
+          }
+        }
+      }
+
+      s"when the user has changed answers on $ExemptionsForSmallProducersPage" - {
+        "should render the check changes page with only the exemptions from small producers section" in {
+          val userAnswers = userAnswerWithExemptionSmallProducerPageUpdatedAndNilSdilReturn
+          given
+            .commonPrecondition
+
+          setAnswers(userAnswers)
+
+          WsTestClient.withClient { client =>
+            val result = createClientRequestGet(client, baseUrl + route)
+
+            whenReady(result) { res =>
+              res.status mustBe OK
+              val page = Jsoup.parse(res.body)
+              page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
+              page.getElementsByClass("govuk-summary-list").size() mustBe 1
+
+              val contractPackedForSmallProducers = page.getElementsByClass("govuk-summary-list").get(0)
+
+              page.getElementsByTag("h2").get(0).text() mustBe "Contract packed for registered small producers"
+              validateContractPackedForSmallProducersWithLitresSummaryList(contractPackedForSmallProducers, smallProducerLitres, true)
+
+              page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
+              page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"
+            }
           }
         }
       }
@@ -41,7 +362,7 @@ class CorrectReturnCheckChangesCYAControllerISpec extends ControllerITTestHelper
 
   "POST " + routes.CorrectReturnCheckChangesCYAController.onSubmit.url - {
     "when the userAnswers contains no data" - {
-      "should redirect to next page" in {
+      "should redirect to index page" in {
         given
           .commonPrecondition
 

--- a/it/controllers/correctReturn/CorrectReturnCheckChangesCYAControllerISpec.scala
+++ b/it/controllers/correctReturn/CorrectReturnCheckChangesCYAControllerISpec.scala
@@ -9,6 +9,7 @@ import play.api.http.Status.OK
 import play.api.libs.json.Json
 import play.api.test.WsTestClient
 import play.mvc.Http.HeaderNames
+import testSupport.SDILBackendTestData.aSubscription
 
 class CorrectReturnCheckChangesCYAControllerISpec extends CorrectReturnBaseCYASummaryISpecHelper {
 
@@ -17,7 +18,7 @@ class CorrectReturnCheckChangesCYAControllerISpec extends CorrectReturnBaseCYASu
   "GET " + routes.CorrectReturnCheckChangesCYAController.onPageLoad.url - {
 
     "when the userAnswers contains no data" - {
-      "should result in a server error" in {
+      "should redirect to select change controller in a server error" in {
         given
           .commonPrecondition
 
@@ -27,7 +28,8 @@ class CorrectReturnCheckChangesCYAControllerISpec extends CorrectReturnBaseCYASu
           val result = createClientRequestGet(client, baseUrl + route)
 
           whenReady(result) { res =>
-            res.status mustBe 500
+            res.status mustBe 303
+            res.header(HeaderNames.LOCATION) mustBe Some(controllers.routes.SelectChangeController.onPageLoad.url)
           }
         }
       }
@@ -48,7 +50,7 @@ class CorrectReturnCheckChangesCYAControllerISpec extends CorrectReturnBaseCYASu
             res.status mustBe OK
             val page = Jsoup.parse(res.body)
             page.title mustBe "Check your answers before sending your correction - Soft Drinks Industry Levy - GOV.UK"
-            page.getElementsByClass("govuk-summary-list").size() mustBe 7
+            page.getElementsByClass("govuk-summary-list").size() mustBe 8
 
             val operatePackagingSites = page.getElementsByClass("govuk-summary-list").get(0)
 
@@ -84,6 +86,11 @@ class CorrectReturnCheckChangesCYAControllerISpec extends CorrectReturnBaseCYASu
 
             page.getElementsByTag("h2").get(6).text() mustBe "Lost or destroyed"
             validateLostOrDamagedWithLitresSummaryList(lostOrDamaged, importsLitres, true)
+
+            val siteDetailsSummaryListItem = page.getElementsByClass("govuk-summary-list").get(7)
+
+            page.getElementsByTag("h2").get(7).text() mustBe "UK site details"
+            validateSiteDetailsSummary(userAnswers, aSubscription, siteDetailsSummaryListItem, 0, 2, true)
 
             page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
             page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"
@@ -382,7 +389,7 @@ class CorrectReturnCheckChangesCYAControllerISpec extends CorrectReturnBaseCYASu
               val siteDetailsSummaryListItem = page.getElementsByClass("govuk-summary-list").get(1)
 
               page.getElementsByTag("h2").get(1).text() mustBe "UK site details"
-              validateSiteDetailsSummary(siteDetailsSummaryListItem, 0, numberOfWarehouses = 2, isCheckAnswers = true)
+              validateSiteDetailsSummary(userAnswers, aSubscription, siteDetailsSummaryListItem, 0, numberOfWarehouses = 2, isCheckAnswers = true)
 
               page.getElementsByTag("form").first().attr("action") mustBe routes.CorrectReturnCheckChangesCYAController.onSubmit.url
               page.getElementsByTag("form").first().getElementsByTag("button").first().text() mustBe "Confirm details and send correction"

--- a/it/testSupport/ITCoreTestData.scala
+++ b/it/testSupport/ITCoreTestData.scala
@@ -53,4 +53,17 @@ trait ITCoreTestData
     contact = Contact(Some("Ava Adams"), Some("Chief Infrastructure Agent"), "04495 206189", "Adeline.Greene@gmail.com"),
     deregDate = None
   )
+
+  val diffSubscriptionWithWarehouses: RetrievedSubscription = RetrievedSubscription(
+    utr = "0000001611",
+    sdilRef = "XKSDIL000000022",
+    orgName = "Super Lemonade Plc",
+    address = UkAddress(List("63 Clifton Roundabout", "Worcester"), "WR53 7CX"),
+    activity = RetrievedActivity(smallProducer = false, largeProducer = true, contractPacker = false, importer = false, voluntaryRegistration = false),
+    liabilityDate = LocalDate.of(2018, 4, 19),
+    productionSites = List(),
+    warehouseSites = List(Site(UkAddress(List("63 Clifton Roundabout", "Worcester"), "WR53 7CX", None), None, Some("Super Lemonade Plc"), None)),
+    contact = Contact(Some("Ava Adams"), Some("Chief Infrastructure Agent"), "04495 206189", "Adeline.Greene@gmail.com"),
+    deregDate = None
+  )
 }

--- a/it/testSupport/ITCoreTestDataForCorrectReturn.scala
+++ b/it/testSupport/ITCoreTestDataForCorrectReturn.scala
@@ -119,5 +119,12 @@ trait ITCoreTestDataForCorrectReturn extends ITSharedCoreTestData  {
     correctReturnPeriod = Some(ReturnPeriod(2023, 0))
   )
 
+  def emptyUserAnswersForCorrectReturnWithWarehouses: UserAnswers = UserAnswers(sdilNumber, SelectChange.CorrectReturn, Json.obj(),
+    packagingSiteList = packagingSitesFromSubscription,
+    warehouseList = warehousesFromSubscription,
+    contactAddress = ukAddress,
+    correctReturnPeriod = Some(ReturnPeriod(2023, 0))
+  )
+
 
 }

--- a/it/testSupport/ITCoreTestDataForCorrectReturn.scala
+++ b/it/testSupport/ITCoreTestDataForCorrectReturn.scala
@@ -119,12 +119,4 @@ trait ITCoreTestDataForCorrectReturn extends ITSharedCoreTestData  {
     correctReturnPeriod = Some(ReturnPeriod(2023, 0))
   )
 
-  def emptyUserAnswersForCorrectReturnWithWarehouses: UserAnswers = UserAnswers(sdilNumber, SelectChange.CorrectReturn, Json.obj(),
-    packagingSiteList = packagingSitesFromSubscription,
-    warehouseList = warehousesFromSubscription,
-    contactAddress = ukAddress,
-    correctReturnPeriod = Some(ReturnPeriod(2023, 0))
-  )
-
-
 }

--- a/test/base/TestData.scala
+++ b/test/base/TestData.scala
@@ -22,7 +22,7 @@ import models.correctReturn.CorrectReturnUserAnswersData
 import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import play.api.libs.json.Json
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
 
 trait TestData {
 
@@ -164,10 +164,14 @@ trait TestData {
       .setForCorrectReturn(correctReturnData, smallProducers, returnPeriod.head).success.value
   }
 
+  val emptySdilReturn: SdilReturn = SdilReturn((0, 0), (0, 0), List.empty, (0, 0), (0, 0), (0, 0), (0, 0), submittedOn =
+    Some(submittedDateTime.toInstant(ZoneOffset.UTC)))
+
+  val userAnswersForCorrectReturnWithEmptySdilReturn:
+    UserAnswers = userAnswersForCorrectReturn(true).copy(data = Json.obj("originalSDILReturn" -> Json.toJson(emptySdilReturn)))
   val userAnswerTwoWarehouses: UserAnswers = userAnswersForCorrectReturn(true).copy(warehouseList = twoWarehouses)
+  val emptyUserAnswersForCancelRegistration: UserAnswers = UserAnswers(sdilNumber, SelectChange.CancelRegistration, contactAddress = contactAddress)
 
-  val emptyUserAnswersForCancelRegistration = UserAnswers(sdilNumber, SelectChange.CancelRegistration, contactAddress = contactAddress)
-
-  def emptyUserAnswersForSelectChange(selectChange: SelectChange) = UserAnswers(sdilNumber, selectChange, contactAddress = contactAddress)
+  def emptyUserAnswersForSelectChange(selectChange: SelectChange): UserAnswers = UserAnswers(sdilNumber, selectChange, contactAddress = contactAddress)
 
 }

--- a/test/controllers/correctReturn/CorrectReturnCheckChangesCYAControllerSpec.scala
+++ b/test/controllers/correctReturn/CorrectReturnCheckChangesCYAControllerSpec.scala
@@ -34,7 +34,7 @@ class CorrectReturnCheckChangesCYAControllerSpec extends SpecBase with SummaryLi
 
     "must return OK and the correct view for a GET" - {
       val litres = LitresInBands(2000, 4000)
-      val userAnswers = emptyUserAnswersForCorrectReturn
+      val userAnswers = userAnswersForCorrectReturnWithEmptySdilReturn
         .copy(packagingSiteList = Map.empty, warehouseList = Map.empty,
           smallProducerList = List(SmallProducer("", "XZSDIL000000234", (2000, 4000))))
         .set(OperatePackagingSiteOwnBrandsPage, true).success.value

--- a/test/models/correctReturn/ChangedPageSpec.scala
+++ b/test/models/correctReturn/ChangedPageSpec.scala
@@ -28,17 +28,19 @@ class ChangedPageSpec extends AnyFreeSpec with Matchers {
       val currentSdilReturn = SdilReturn((1, 1), (3, 4), List(SmallProducer("", "", (1, 1))), (5, 6), (33, 22), (32, 22), (22, 22), None)
       val res = ChangedPage.returnLiteragePagesThatChangedComparedToOriginalReturn(originalSdilReturn, currentSdilReturn)
       res mustBe List(
-        ChangedPage(OperatePackagingSiteOwnBrandsPage, true),
-        ChangedPage(HowManyOperatePackagingSiteOwnBrandsPage, true),
-        ChangedPage(PackagedAsContractPackerPage, true),
-        ChangedPage(HowManyPackagedAsContractPackerPage, true),
-        ChangedPage(BroughtIntoUKPage, true),
-        ChangedPage(HowManyBroughtIntoUKPage, true),
-        ChangedPage(BroughtIntoUkFromSmallProducersPage, true),
-        ChangedPage(HowManyBroughtIntoUkFromSmallProducersPage, true),
-        ChangedPage(ClaimCreditsForExportsPage, true),
-        ChangedPage(HowManyClaimCreditsForExportsPage, true),
-        ChangedPage(ExemptionsForSmallProducersPage, true)
+        ChangedPage(OperatePackagingSiteOwnBrandsPage, answerChanged = true),
+        ChangedPage(HowManyOperatePackagingSiteOwnBrandsPage, answerChanged = true),
+        ChangedPage(PackagedAsContractPackerPage, answerChanged = true),
+        ChangedPage(HowManyPackagedAsContractPackerPage, answerChanged = true),
+        ChangedPage(BroughtIntoUKPage, answerChanged = true),
+        ChangedPage(HowManyBroughtIntoUKPage, answerChanged = true),
+        ChangedPage(BroughtIntoUkFromSmallProducersPage, answerChanged = true),
+        ChangedPage(HowManyBroughtIntoUkFromSmallProducersPage, answerChanged = true),
+        ChangedPage(ClaimCreditsForExportsPage, answerChanged = true),
+        ChangedPage(HowManyClaimCreditsForExportsPage, answerChanged = true),
+        ChangedPage(ClaimCreditsForLostDamagedPage, answerChanged = true),
+        ChangedPage(HowManyCreditsForLostDamagedPage, answerChanged = true),
+        ChangedPage(ExemptionsForSmallProducersPage, answerChanged = true)
       )
     }
     "should return all pages with answers changed false that have changed if all answers remain the same" in {
@@ -46,17 +48,19 @@ class ChangedPageSpec extends AnyFreeSpec with Matchers {
       val currentSdilReturn = SdilReturn((0, 0), (0, 0), List(), (0, 0), (0, 0), (0, 0), (0, 0), None)
       val res = ChangedPage.returnLiteragePagesThatChangedComparedToOriginalReturn(originalSdilReturn, currentSdilReturn)
       res mustBe List(
-        ChangedPage(OperatePackagingSiteOwnBrandsPage, false),
-        ChangedPage(HowManyOperatePackagingSiteOwnBrandsPage, false),
-        ChangedPage(PackagedAsContractPackerPage, false),
-        ChangedPage(HowManyPackagedAsContractPackerPage, false),
-        ChangedPage(BroughtIntoUKPage, false),
-        ChangedPage(HowManyBroughtIntoUKPage, false),
-        ChangedPage(BroughtIntoUkFromSmallProducersPage, false),
-        ChangedPage(HowManyBroughtIntoUkFromSmallProducersPage, false),
-        ChangedPage(ClaimCreditsForExportsPage, false),
-        ChangedPage(HowManyClaimCreditsForExportsPage, false),
-        ChangedPage(ExemptionsForSmallProducersPage, false)
+        ChangedPage(OperatePackagingSiteOwnBrandsPage, answerChanged = false),
+        ChangedPage(HowManyOperatePackagingSiteOwnBrandsPage, answerChanged = false),
+        ChangedPage(PackagedAsContractPackerPage, answerChanged = false),
+        ChangedPage(HowManyPackagedAsContractPackerPage, answerChanged = false),
+        ChangedPage(BroughtIntoUKPage, answerChanged = false),
+        ChangedPage(HowManyBroughtIntoUKPage, answerChanged = false),
+        ChangedPage(BroughtIntoUkFromSmallProducersPage, answerChanged = false),
+        ChangedPage(HowManyBroughtIntoUkFromSmallProducersPage, answerChanged = false),
+        ChangedPage(ClaimCreditsForExportsPage, answerChanged = false),
+        ChangedPage(HowManyClaimCreditsForExportsPage, answerChanged = false),
+        ChangedPage(ClaimCreditsForLostDamagedPage, answerChanged = false),
+        ChangedPage(HowManyCreditsForLostDamagedPage, answerChanged = false),
+        ChangedPage(ExemptionsForSmallProducersPage, answerChanged = false)
       )
     }
     s"should return all pages answered change true bar the $ExemptionsForSmallProducersPage if the small producers literages has not changed" in {
@@ -64,17 +68,19 @@ class ChangedPageSpec extends AnyFreeSpec with Matchers {
       val currentSdilReturn = SdilReturn((1, 1), (3, 4), List(SmallProducer("", "", (1, 1))), (5, 6), (33, 22), (32, 22), (22, 22), None)
       val res = ChangedPage.returnLiteragePagesThatChangedComparedToOriginalReturn(originalSdilReturn, currentSdilReturn)
        res mustBe List(
-        ChangedPage(OperatePackagingSiteOwnBrandsPage, true),
-        ChangedPage(HowManyOperatePackagingSiteOwnBrandsPage, true),
-        ChangedPage(PackagedAsContractPackerPage, true),
-        ChangedPage(HowManyPackagedAsContractPackerPage, true),
-        ChangedPage(BroughtIntoUKPage, true),
-        ChangedPage(HowManyBroughtIntoUKPage, true),
-        ChangedPage(BroughtIntoUkFromSmallProducersPage, true),
-        ChangedPage(HowManyBroughtIntoUkFromSmallProducersPage, true),
-        ChangedPage(ClaimCreditsForExportsPage, true),
-        ChangedPage(HowManyClaimCreditsForExportsPage, true),
-        ChangedPage(ExemptionsForSmallProducersPage, false)
+        ChangedPage(OperatePackagingSiteOwnBrandsPage, answerChanged = true),
+        ChangedPage(HowManyOperatePackagingSiteOwnBrandsPage, answerChanged =  true),
+        ChangedPage(PackagedAsContractPackerPage, answerChanged =  true),
+        ChangedPage(HowManyPackagedAsContractPackerPage, answerChanged =  true),
+        ChangedPage(BroughtIntoUKPage, answerChanged =  true),
+        ChangedPage(HowManyBroughtIntoUKPage, answerChanged =  true),
+        ChangedPage(BroughtIntoUkFromSmallProducersPage, answerChanged =  true),
+        ChangedPage(HowManyBroughtIntoUkFromSmallProducersPage, answerChanged =  true),
+        ChangedPage(ClaimCreditsForExportsPage, answerChanged =  true),
+        ChangedPage(HowManyClaimCreditsForExportsPage, answerChanged =  true),
+        ChangedPage(ClaimCreditsForLostDamagedPage, answerChanged = true),
+        ChangedPage(HowManyCreditsForLostDamagedPage, answerChanged = true),
+        ChangedPage(ExemptionsForSmallProducersPage, answerChanged =  false)
       )
     }
   }

--- a/test/views/correctReturn/CorrectReturnCheckChangesCYAViewSpec.scala
+++ b/test/views/correctReturn/CorrectReturnCheckChangesCYAViewSpec.scala
@@ -60,7 +60,7 @@ class CorrectReturnCheckChangesCYAViewSpec extends ViewSpecHelper {
     }
 
     "should have the expected post header caption" in {
-      document.getElementsByClass(Selectors.body).text() mustEqual "This update is for Super Lemonade Plc"
+      document.getElementsByClass(Selectors.body).get(0).text() mustEqual "This update is for Super Lemonade Plc"
     }
 
     "contain the correct button" in {
@@ -80,6 +80,11 @@ class CorrectReturnCheckChangesCYAViewSpec extends ViewSpecHelper {
         .getElementsByClass(Selectors.summaryRow)
         .first()
         .getElementsByClass(Selectors.summaryValue).first().text() mustBe "bang"
+    }
+
+    "contain a section before the submit action that contains the correct text" in {
+      document.getElementsByClass(Selectors.body).get(1).text() mustBe
+        "By sending this correction you are confirming that, to the best of your knowledge, the details you are providing are correct."
     }
 
     "contains a form with the correct action" in {

--- a/test/views/summary/correctReturn/CorrectReturnBaseCYASummarySpec.scala
+++ b/test/views/summary/correctReturn/CorrectReturnBaseCYASummarySpec.scala
@@ -48,7 +48,8 @@ class CorrectReturnBaseCYASummarySpec extends SpecBase {
         res.rows(1).key.classes mustBe ""
         res.rows(1).value.content.asHtml mustBe Html(java.text.NumberFormat.getInstance.format(lowLitres))
         res.rows(1).value.classes.trim mustBe "govuk-!-text-align-right"
-        res.rows(1).actions.head.items.head.href mustBe "/soft-drinks-industry-levy-variations-frontend/change-activity/change-how-many-contract-packing-next-12-months"
+        res.rows(1).actions.head.items.head.href mustBe
+          "/soft-drinks-industry-levy-variations-frontend/change-activity/change-how-many-contract-packing-next-12-months"
         res.rows(1).actions.head.items.head.attributes mustBe Map("id" -> "change-lowband-litreage-contractPacking")
         res.rows(1).actions.head.items.head.content.asHtml mustBe Html("Change")
 
@@ -58,7 +59,8 @@ class CorrectReturnBaseCYASummarySpec extends SpecBase {
         res.rows(highLitresRowIndex).key.classes mustBe ""
         res.rows(highLitresRowIndex).value.content.asHtml mustBe Html(java.text.NumberFormat.getInstance.format(highLitres))
         res.rows(highLitresRowIndex).value.classes.trim mustBe "govuk-!-text-align-right"
-        res.rows(highLitresRowIndex).actions.head.items.head.href mustBe "/soft-drinks-industry-levy-variations-frontend/change-activity/change-how-many-contract-packing-next-12-months"
+        res.rows(highLitresRowIndex).actions.head.items.head.href mustBe
+          "/soft-drinks-industry-levy-variations-frontend/change-activity/change-how-many-contract-packing-next-12-months"
         res.rows(highLitresRowIndex).actions.head.items.head.attributes mustBe Map("id" -> "change-highband-litreage-contractPacking")
         res.rows(highLitresRowIndex).actions.head.items.head.content.asHtml mustBe Html("Change")
 


### PR DESCRIPTION
This PR focuses mainly on added method to CorrectReturnsBaseCYA file to handle difference for check changes page and the integration tests on the check changes controller.  
Work is still needed to finalise this ticket, including adding the balance/total section and the correction reason and repayment method sections.  These will be done in next PR