### PR TITLE
DLS-8895 removing warehouse class and using site instead

### DIFF
--- a/app/controllers/cancelRegistration/FileReturnBeforeDeregController.scala
+++ b/app/controllers/cancelRegistration/FileReturnBeforeDeregController.scala
@@ -50,7 +50,7 @@ class FileReturnBeforeDeregController @Inject()(
   }
 
   def onSubmit(): Action[AnyContent] = controllerActions.withRequiredJourneyData(SelectChange.CancelRegistration) {
-    implicit request => Redirect(config.sdilHomeUrl)
+    _ => Redirect(config.sdilHomeUrl)
   }
 
 }

--- a/app/controllers/changeActivity/RemoveWarehouseDetailsController.scala
+++ b/app/controllers/changeActivity/RemoveWarehouseDetailsController.scala
@@ -21,7 +21,8 @@ import controllers.actions._
 import forms.changeActivity.RemoveWarehouseDetailsFormProvider
 import handlers.ErrorHandler
 import models.SelectChange.ChangeActivity
-import models.{NormalMode, UserAnswers, Warehouse}
+import models.backend.Site
+import models.{NormalMode, UserAnswers}
 import navigation._
 import pages.changeActivity.RemoveWarehouseDetailsPage
 import play.api.data.Form
@@ -62,7 +63,7 @@ class RemoveWarehouseDetailsController @Inject()(
 
   def onSubmit(index: String): Action[AnyContent] = controllerActions.withRequiredJourneyData(ChangeActivity).async {
     implicit request =>
-      val warehouseToRemove: Option[Warehouse] = request.userAnswers.warehouseList.get(index)
+      val warehouseToRemove: Option[Site] = request.userAnswers.warehouseList.get(index)
       warehouseToRemove match {
         case None =>
           Future.successful(indexNotFoundRedirect(index, request, controllers.changeActivity.routes.SecondaryWarehouseDetailsController.onPageLoad))

--- a/app/controllers/correctReturn/RemoveWarehouseDetailsController.scala
+++ b/app/controllers/correctReturn/RemoveWarehouseDetailsController.scala
@@ -20,7 +20,8 @@ import controllers.actions._
 import controllers.{ControllerHelper, routes}
 import forms.correctReturn.RemoveWarehouseDetailsFormProvider
 import handlers.ErrorHandler
-import models.{Mode, UserAnswers, Warehouse}
+import models.backend.Site
+import models.{Mode, UserAnswers}
 import navigation._
 import pages.correctReturn.RemoveWarehouseDetailsPage
 import play.api.data.Form
@@ -61,7 +62,7 @@ class RemoveWarehouseDetailsController @Inject()(
 
   def onSubmit(mode: Mode, index: String): Action[AnyContent] = controllerActions.withCorrectReturnJourneyData.async {
     implicit request =>
-      val warehouseToRemove: Option[Warehouse] = request.userAnswers.warehouseList.get(index)
+      val warehouseToRemove: Option[Site] = request.userAnswers.warehouseList.get(index)
       warehouseToRemove match {
         case None =>
           Future.successful(indexNotFoundRedirect(index, request, routes.IndexController.onPageLoad))

--- a/app/controllers/updateRegisteredDetails/RemoveWarehouseDetailsController.scala
+++ b/app/controllers/updateRegisteredDetails/RemoveWarehouseDetailsController.scala
@@ -16,12 +16,13 @@
 
 package controllers.updateRegisteredDetails
 
-import controllers.actions._
 import controllers.ControllerHelper
+import controllers.actions._
 import forms.updateRegisteredDetails.RemoveWarehouseDetailsFormProvider
 import handlers.ErrorHandler
 import models.SelectChange.UpdateRegisteredDetails
-import models.{Mode, UserAnswers, Warehouse}
+import models.backend.Site
+import models.{Mode, UserAnswers}
 import navigation._
 import pages.updateRegisteredDetails.RemoveWarehouseDetailsPage
 import play.api.data.Form
@@ -62,7 +63,7 @@ class RemoveWarehouseDetailsController @Inject()(
 
   def onSubmit(mode: Mode, index: String): Action[AnyContent] = controllerActions.withRequiredJourneyData(UpdateRegisteredDetails).async {
     implicit request =>
-      val warehouseToRemove: Option[Warehouse] = request.userAnswers.warehouseList.get(index)
+      val warehouseToRemove: Option[Site] = request.userAnswers.warehouseList.get(index)
       warehouseToRemove match {
         case None =>
           Future.successful(indexNotFoundRedirect(index, request, routes.WarehouseDetailsController.onPageLoad(mode)))

--- a/app/models/ModelEncryption.scala
+++ b/app/models/ModelEncryption.scala
@@ -76,7 +76,7 @@ object ModelEncryption {
       data = Json.parse(encryption.crypto.decrypt(data, id)).as[JsObject],
       smallProducerList = Json.parse(encryption.crypto.decrypt(smallProducerList, id)).as[List[SmallProducer]],
       packagingSiteList = packagingSiteList.map(site => site._1 -> Json.parse(encryption.crypto.decrypt(site._2, id)).as[Site]),
-      warehouseList = warehouseList.map(warehouse => warehouse._1 -> Json.parse(encryption.crypto.decrypt(warehouse._2, id)).as[Warehouse]),
+      warehouseList = warehouseList.map(warehouse => warehouse._1 -> Json.parse(encryption.crypto.decrypt(warehouse._2, id)).as[Site]),
       contactAddress = Json.parse(encryption.crypto.decrypt(contactAddress, id)).as[UkAddress],
       correctReturnPeriod = correctReturnPeriod,
       submitted = submitted,

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -34,7 +34,7 @@ case class UserAnswers(
                         data: JsObject = Json.obj(),
                         smallProducerList: List[SmallProducer] = List.empty,
                         packagingSiteList: Map[String, Site] = Map.empty,
-                        warehouseList: Map[String, Warehouse] = Map.empty,
+                        warehouseList: Map[String, Site] = Map.empty,
                         contactAddress: UkAddress,
                         correctReturnPeriod: Option[ReturnPeriod] = None,
                         submitted:Boolean = false,

--- a/app/models/backend/Site.scala
+++ b/app/models/backend/Site.scala
@@ -16,21 +16,16 @@
 
 package models.backend
 
-import models.Warehouse
-
-import java.time.LocalDate
 import play.api.libs.json.{Format, Json}
 
-case class Site(
-                 address: UkAddress,
-                 ref: Option[String],
-                 tradingName: Option[String],
-                 closureDate: Option[LocalDate]
+import java.time.LocalDate
+
+case class Site(address: UkAddress,
+                 tradingName: Option[String] = None,
+                 ref: Option[String] = None,
+                 closureDate: Option[LocalDate] = None
                )
 
 object Site {
   implicit val format: Format[Site] = Json.format[Site]
-
-  def fromWarehouse(warehouse: Warehouse): Site =
-    Site(warehouse.address, None, warehouse.tradingName, None)
 }

--- a/app/models/backend/VariationsSIte.scala
+++ b/app/models/backend/VariationsSIte.scala
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 
-package models
+package models.backend
 
-import models.backend.{Site, UkAddress}
-import play.api.libs.json.{Format, Json}
+import models.updateRegisteredDetails.Submission.VariationsContact
 
-case class Warehouse(tradingName: Option[String],
-                     address: UkAddress)
-
-object Warehouse {
-  implicit val format: Format[Warehouse] = Json.format[Warehouse]
-
-  def fromSite(site: Site): Warehouse = {
-    Warehouse(site.tradingName, site.address)
-  }
-}
+case class VariationsSite(tradingName: String,
+                          siteReference: String,
+                          variationsContact: VariationsContact,
+                          typeOfSite: String)

--- a/app/navigation/NavigatorForCancelRegistration.scala
+++ b/app/navigation/NavigatorForCancelRegistration.scala
@@ -28,13 +28,12 @@ import javax.inject.{Inject, Singleton}
 class NavigatorForCancelRegistration @Inject()() extends Navigator {
 
   override val normalRoutes: Page => UserAnswers => Call = {
-    case CancelRegistrationDatePage => userAnswers => routes.CancelRegistrationCYAController.onPageLoad
-    case ReasonPage => userAnswers => routes.CancelRegistrationDateController.onPageLoad(mode = NormalMode)
+    case CancelRegistrationDatePage => _ => routes.CancelRegistrationCYAController.onPageLoad
+    case ReasonPage => _ => routes.CancelRegistrationDateController.onPageLoad(mode = NormalMode)
     case _ => _ => defaultCall
   }
 
   override val checkRouteMap: Page => UserAnswers => Call = {
     case _ => _ => routes.CancelRegistrationCYAController.onPageLoad
-    case ReasonPage => _ => routes.CancelRegistrationCYAController.onPageLoad
   }
 }

--- a/app/orchestrators/SelectChangeOrchestrator.scala
+++ b/app/orchestrators/SelectChangeOrchestrator.scala
@@ -23,7 +23,7 @@ import connectors.SoftDrinksIndustryLevyConnector
 import errors.{ReturnsStillPending, VariationsErrors}
 import models.backend.Site
 import models.updateRegisteredDetails.ContactDetails
-import models.{RetrievedSubscription, SelectChange, UserAnswers, Warehouse}
+import models.{RetrievedSubscription, SelectChange, UserAnswers}
 import pages.updateRegisteredDetails.UpdateContactDetailsPage
 import service.VariationResult
 import services.SessionService
@@ -86,8 +86,8 @@ class SelectChangeOrchestrator @Inject()(sessionService: SessionService,
     UserAnswers(id = subscription.sdilRef,
       journeyType = value,
       contactAddress = subscription.address,
-      packagingSiteList = getNoneClosedPackagingSites(subscription.productionSites),
-      warehouseList = getNoneClosedWarehouses(subscription.warehouseSites),
+      packagingSiteList = getNoneClosedSites(subscription.productionSites),
+      warehouseList = getNoneClosedSites(subscription.warehouseSites),
       lastUpdated = timeNow)
   }
 
@@ -96,26 +96,19 @@ class SelectChangeOrchestrator @Inject()(sessionService: SessionService,
     Future.fromTry(UserAnswers(id = subscription.sdilRef,
       journeyType = SelectChange.UpdateRegisteredDetails,
       contactAddress = subscription.address,
-      packagingSiteList = getNoneClosedPackagingSites(subscription.productionSites),
-      warehouseList = getNoneClosedWarehouses(subscription.warehouseSites),
+      packagingSiteList = getNoneClosedSites(subscription.productionSites),
+      warehouseList = getNoneClosedSites(subscription.warehouseSites),
       lastUpdated = timeNow)
       .set(UpdateContactDetailsPage, contactDetails)
     )
 
   }
 
-  private def getNoneClosedPackagingSites(productionSites: List[Site]): Map[String, Site] = {
-    val productionSitesNotClosed = productionSites.filter(site => site.closureDate.forall(_.isAfter(LocalDate.now)))
-    productionSitesNotClosed.zipWithIndex
+  private def getNoneClosedSites(sites: List[Site]): Map[String, Site] = {
+    val sitesNotClosed = sites.filter(site => site.closureDate.forall(_.isAfter(LocalDate.now)))
+    sitesNotClosed.zipWithIndex
       .map { case (site, index) => (index.toString, site) }
       .toMap[String, Site]
-  }
-
-  private def getNoneClosedWarehouses(warehouses: List[Site]): Map[String, Warehouse] = {
-    val productionSitesNotClosed = warehouses.filter(site => site.closureDate.forall(_.isAfter(LocalDate.now)))
-    productionSitesNotClosed.zipWithIndex
-      .map { case (site, index) => (index.toString, Warehouse.fromSite(site)) }
-      .toMap[String, Warehouse]
   }
 
   def timeNow: Instant = Instant.now()

--- a/app/services/AddressLookupService.scala
+++ b/app/services/AddressLookupService.scala
@@ -20,7 +20,7 @@ import config.FrontendAppConfig
 import connectors.AddressLookupConnector
 import connectors.httpParsers.ResponseHttpParser.HttpResult
 import controllers.routes
-import models.{UserAnswers, Warehouse}
+import models.UserAnswers
 import models.alf.init._
 import models.alf.{AlfAddress, AlfResponse}
 import models.backend.{Site, UkAddress}
@@ -71,7 +71,7 @@ class AddressLookupService @Inject()(
           userAnswers.packagingSiteList.filterNot(_._1 == sdilId) ++ Map(sdilId -> Site(convertedAddress, None, address.organisation, None)))
       case WarehouseDetails =>
         userAnswers.copy(warehouseList =
-          userAnswers.warehouseList.filterNot(_._1 == sdilId) ++ Map(sdilId -> Warehouse(address.organisation, convertedAddress)))
+          userAnswers.warehouseList.filterNot(_._1 == sdilId) ++ Map(sdilId -> Site(convertedAddress, address.organisation)))
       case ContactDetails =>
         userAnswers.copy(contactAddress = convertedAddress)
     }

--- a/app/services/ChangeActivityService.scala
+++ b/app/services/ChangeActivityService.scala
@@ -16,7 +16,6 @@
 
 package services
 
-import config.FrontendAppConfig
 import connectors.SoftDrinksIndustryLevyConnector
 import models.backend.Site
 import models.{Convert, Litreage, Producer, RegistrationVariationData, RetrievedSubscription, UserAnswers, VariationsSubmission}

--- a/app/views/summary/cancelRegistration/ReasonSummary.scala
+++ b/app/views/summary/cancelRegistration/ReasonSummary.scala
@@ -20,7 +20,6 @@ import controllers.cancelRegistration.routes
 import models.{CheckMode, UserAnswers}
 import pages.cancelRegistration.ReasonPage
 import play.api.i18n.Messages
-import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._

--- a/app/views/summary/changeActivity/SecondaryWarehouseDetailsSummary.scala
+++ b/app/views/summary/changeActivity/SecondaryWarehouseDetailsSummary.scala
@@ -17,7 +17,8 @@
 package views.summary.changeActivity
 
 import controllers.changeActivity.routes
-import models.{UserAnswers, Warehouse}
+import models.UserAnswers
+import models.backend.Site
 import pages.changeActivity.SecondaryWarehouseDetailsPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{Actions, Key}
@@ -45,7 +46,7 @@ object SecondaryWarehouseDetailsSummary  {
         )
     }
 
-  def summaryRows(warehouseList: Map[String, Warehouse])(implicit messages: Messages): List[SummaryListRow] = {
+  def summaryRows(warehouseList: Map[String, Site])(implicit messages: Messages): List[SummaryListRow] = {
     warehouseList.map {
       warehouse =>
         SummaryListRow(

--- a/app/views/summary/correctReturn/SecondaryWarehouseDetailsSummary.scala
+++ b/app/views/summary/correctReturn/SecondaryWarehouseDetailsSummary.scala
@@ -17,7 +17,8 @@
 package viewmodels.summary.correctReturn
 
 import controllers.correctReturn.routes
-import models.{CheckMode, UserAnswers, Warehouse}
+import models.backend.Site
+import models.{CheckMode, UserAnswers}
 import pages.correctReturn.SecondaryWarehouseDetailsPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{Actions, Key}
@@ -45,7 +46,7 @@ object SecondaryWarehouseDetailsSummary  {
         )
     }
 
-  def row2(warehouseList: Map[String, Warehouse])(implicit messages: Messages): List[SummaryListRow] = {
+  def row2(warehouseList: Map[String, Site])(implicit messages: Messages): List[SummaryListRow] = {
     warehouseList.map {
       warehouse =>
         SummaryListRow(

--- a/app/views/summary/updateRegisteredDetails/BusinessAddressSummary.scala
+++ b/app/views/summary/updateRegisteredDetails/BusinessAddressSummary.scala
@@ -18,7 +18,6 @@ package views.summary.updateRegisteredDetails
 
 import models.UserAnswers
 import models.backend.UkAddress
-import pages.updateRegisteredDetails.BusinessAddressPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{Actions, Key}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent

--- a/app/views/summary/updateRegisteredDetails/PackagingSiteDetailsSummary.scala
+++ b/app/views/summary/updateRegisteredDetails/PackagingSiteDetailsSummary.scala
@@ -18,7 +18,7 @@ package views.summary.updateRegisteredDetails
 
 import controllers.updateRegisteredDetails.routes
 import models.backend.Site
-import models.{CheckMode, Mode, NormalMode, UserAnswers}
+import models.{CheckMode, Mode, UserAnswers}
 import pages.updateRegisteredDetails.PackagingSiteDetailsPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{Actions, Key}

--- a/app/views/summary/updateRegisteredDetails/WarehouseDetailsSummary.scala
+++ b/app/views/summary/updateRegisteredDetails/WarehouseDetailsSummary.scala
@@ -17,7 +17,8 @@
 package views.summary.updateRegisteredDetails
 
 import controllers.updateRegisteredDetails.routes
-import models.{CheckMode, Mode, NormalMode, UserAnswers, Warehouse}
+import models.backend.Site
+import models.{CheckMode, Mode, UserAnswers}
 import pages.updateRegisteredDetails.WarehouseDetailsPage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{Actions, Key}
@@ -45,7 +46,7 @@ object WarehouseDetailsSummary  {
         )
     }
 
-  def row2(warehouseList: Map[String, Warehouse], mode: Mode)(implicit messages: Messages): List[SummaryListRow] = {
+  def row2(warehouseList: Map[String, Site], mode: Mode)(implicit messages: Messages): List[SummaryListRow] = {
     warehouseList.map {
           warehouse =>
             SummaryListRow(

--- a/it/controllers/addressLookupFrontend/RampOffControllerISpec.scala
+++ b/it/controllers/addressLookupFrontend/RampOffControllerISpec.scala
@@ -1,7 +1,7 @@
 package controllers.addressLookupFrontend
 
 import controllers.ControllerITTestHelper
-import models.{NormalMode, Warehouse}
+import models.NormalMode
 import models.backend.{Site, UkAddress}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, SEE_OTHER}
@@ -32,8 +32,8 @@ class RampOffControllerISpec extends ControllerITTestHelper {
             updatedUserAnswers.packagingSiteList mustBe emptyUserAnswersForUpdateRegisteredDetails.packagingSiteList
             updatedUserAnswers.submitted mustBe emptyUserAnswersForUpdateRegisteredDetails.submitted
             updatedUserAnswers.smallProducerList mustBe emptyUserAnswersForUpdateRegisteredDetails.smallProducerList
-            updatedUserAnswers.warehouseList mustBe Map(sdilId -> Warehouse(Some("soft drinks ltd"),
-              UkAddress(List("line 1", "line 2", "line 3", "line 4"), "aa1 1aa", alfId = Some(alfId))))
+            updatedUserAnswers.warehouseList mustBe Map(sdilId -> Site(
+              UkAddress(List("line 1", "line 2", "line 3", "line 4"), "aa1 1aa", alfId = Some(alfId)), Some("soft drinks ltd")))
 
             res.status mustBe SEE_OTHER
             res.header(HeaderNames.LOCATION) mustBe Some(controllers.updateRegisteredDetails.routes.WarehouseDetailsController.onPageLoad(NormalMode).url)
@@ -45,7 +45,7 @@ class RampOffControllerISpec extends ControllerITTestHelper {
         val sdilId: String = "foo"
         val alfId: String = "bar"
         val userAnswersBefore = emptyUserAnswersForUpdateRegisteredDetails.copy(
-          warehouseList = Map(sdilId -> Warehouse(None, UkAddress(List.empty, "foo", Some("wizz")))))
+          warehouseList = Map(sdilId -> Site(UkAddress(List.empty, "foo", Some("wizz")))))
         given
           .commonPrecondition
           .alf.getAddress(alfId)
@@ -61,8 +61,8 @@ class RampOffControllerISpec extends ControllerITTestHelper {
             updatedUserAnswers.packagingSiteList mustBe emptyUserAnswersForUpdateRegisteredDetails.packagingSiteList
             updatedUserAnswers.submitted mustBe emptyUserAnswersForUpdateRegisteredDetails.submitted
             updatedUserAnswers.smallProducerList mustBe emptyUserAnswersForUpdateRegisteredDetails.smallProducerList
-            updatedUserAnswers.warehouseList mustBe Map(sdilId -> Warehouse(Some("soft drinks ltd"),
-              UkAddress(List("line 1", "line 2", "line 3", "line 4"), "aa1 1aa", alfId = Some(alfId))))
+            updatedUserAnswers.warehouseList mustBe Map(sdilId -> Site(
+              UkAddress(List("line 1", "line 2", "line 3", "line 4"), "aa1 1aa", alfId = Some(alfId)), Some("soft drinks ltd")))
 
             res.status mustBe SEE_OTHER
             res.header(HeaderNames.LOCATION) mustBe Some(controllers.updateRegisteredDetails.routes.WarehouseDetailsController.onPageLoad(NormalMode).url)

--- a/it/controllers/cancelRegistration/ReasonControllerISpec.scala
+++ b/it/controllers/cancelRegistration/ReasonControllerISpec.scala
@@ -5,7 +5,7 @@ import models.SelectChange.CancelRegistration
 import models.{NormalMode, UserAnswers}
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.{convertToAnyMustWrapper, include}
-import pages.cancelRegistration.{CancelRegistrationDatePage, ReasonPage}
+import pages.cancelRegistration.ReasonPage
 import play.api.http.HeaderNames
 import play.api.i18n.Messages
 import play.api.libs.json.Json

--- a/it/controllers/changeActivity/RemoveWarehouseDetailsControllerISpec.scala
+++ b/it/controllers/changeActivity/RemoveWarehouseDetailsControllerISpec.scala
@@ -2,7 +2,7 @@ package controllers.changeActivity
 
 import controllers.ControllerITTestHelper
 import models.SelectChange.ChangeActivity
-import models.Warehouse
+import models.backend.Site
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import pages.changeActivity._
@@ -127,7 +127,7 @@ class RemoveWarehouseDetailsControllerISpec extends ControllerITTestHelper {
 
         setAnswers(
           emptyUserAnswersForChangeActivity
-            .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Warehouse(None, ukAddress))))
+            .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Site(ukAddress))))
         getAnswers(emptyUserAnswersForChangeActivity.id).get.warehouseList.size mustBe 1
         WsTestClient.withClient { client =>
           val result = createClientRequestPOST(

--- a/it/controllers/changeActivity/SecondaryWarehouseDetailsControllerISpec.scala
+++ b/it/controllers/changeActivity/SecondaryWarehouseDetailsControllerISpec.scala
@@ -2,9 +2,8 @@ package controllers.changeActivity
 
 import controllers.ControllerITTestHelper
 import models.SelectChange.ChangeActivity
-import models.Warehouse
 import models.alf.init._
-import models.backend.UkAddress
+import models.backend.{Site, UkAddress}
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import pages.changeActivity.SecondaryWarehouseDetailsPage
@@ -50,8 +49,8 @@ class SecondaryWarehouseDetailsControllerISpec extends ControllerITTestHelper {
 
     "GET "  - {
       "when the userAnswers contains some warehouses" - {
-        val singleWarehouse = Map("1" -> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy"), "WR53 7CX")))
-        val multipleWarehouses = singleWarehouse ++ Map("2" -> Warehouse(Some("ACME Soft Drinks"), UkAddress(List("1 Watch Street"), "DF4 3WE")))
+        val singleWarehouse = Map("1" -> Site(UkAddress(List("33 Rhes Priordy"), "WR53 7CX"), Some("ABC Ltd")))
+        val multipleWarehouses = singleWarehouse ++ Map("2" -> Site(UkAddress(List("1 Watch Street"), "DF4 3WE"), Some("ACME Soft Drinks")))
         List(singleWarehouse, multipleWarehouses).foreach { warehouseList =>
           "should return OK and render the SecondaryWarehouseDetails page with no data populated " +
             s"(with message displaying summary list of warehouses) for warehouse list size ${warehouseList.size}" in {

--- a/it/controllers/correctReturn/RemoveWarehouseDetailsControllerISpec.scala
+++ b/it/controllers/correctReturn/RemoveWarehouseDetailsControllerISpec.scala
@@ -2,7 +2,7 @@ package controllers.correctReturn
 
 import controllers.ControllerITTestHelper
 import models.SelectChange.CorrectReturn
-import models.Warehouse
+import models.backend.Site
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.{convertToAnyMustWrapper, include}
 import pages.correctReturn.RemoveWarehouseDetailsPage
@@ -179,7 +179,7 @@ class RemoveWarehouseDetailsControllerISpec extends ControllerITTestHelper {
 
         setAnswers(
           emptyUserAnswersForCorrectReturn
-            .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Warehouse(None, ukAddress))))
+            .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Site(ukAddress))))
         getAnswers(emptyUserAnswersForCorrectReturn.id).get.warehouseList.size mustBe 1
         WsTestClient.withClient { client =>
           val result = createClientRequestPOST(
@@ -269,7 +269,7 @@ class RemoveWarehouseDetailsControllerISpec extends ControllerITTestHelper {
 
         setAnswers(
           emptyUserAnswersForCorrectReturn
-            .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Warehouse(None, ukAddress))))
+            .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Site(ukAddress))))
         getAnswers(emptyUserAnswersForCorrectReturn.id).get.warehouseList.size mustBe 1
         WsTestClient.withClient { client =>
           val result = createClientRequestPOST(

--- a/it/controllers/updateRegisteredDetails/RemoveWarehouseDetailsControllerISpec.scala
+++ b/it/controllers/updateRegisteredDetails/RemoveWarehouseDetailsControllerISpec.scala
@@ -2,7 +2,8 @@ package controllers.updateRegisteredDetails
 
 import controllers.ControllerITTestHelper
 import models.SelectChange.UpdateRegisteredDetails
-import models.{CheckMode, NormalMode, Warehouse}
+import models.backend.Site
+import models.{CheckMode, NormalMode}
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.{convertToAnyMustWrapper, include}
 import pages.updateRegisteredDetails.RemoveWarehouseDetailsPage
@@ -179,7 +180,7 @@ class RemoveWarehouseDetailsControllerISpec extends ControllerITTestHelper {
 
         setAnswers(
           emptyUserAnswersForUpdateRegisteredDetails
-            .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Warehouse(None, ukAddress))))
+            .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Site(ukAddress))))
         getAnswers(emptyUserAnswersForUpdateRegisteredDetails.id).get.warehouseList.size mustBe 1
         WsTestClient.withClient { client =>
           val result = createClientRequestPOST(
@@ -269,7 +270,7 @@ class RemoveWarehouseDetailsControllerISpec extends ControllerITTestHelper {
 
         setAnswers(
           emptyUserAnswersForUpdateRegisteredDetails
-            .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Warehouse(None, ukAddress))))
+            .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Site(ukAddress))))
         getAnswers(emptyUserAnswersForUpdateRegisteredDetails.id).get.warehouseList.size mustBe 1
         WsTestClient.withClient { client =>
           val result = createClientRequestPOST(

--- a/it/controllers/updateRegisteredDetails/WarehouseDetailsControllerISpec.scala
+++ b/it/controllers/updateRegisteredDetails/WarehouseDetailsControllerISpec.scala
@@ -2,11 +2,11 @@ package controllers.updateRegisteredDetails
 
 import controllers.ControllerITTestHelper
 import models.SelectChange.{UpdateRegisteredDetails, writes}
-import models.{NormalMode, UserAnswers, Warehouse}
 import models.alf.init._
-import models.backend.UkAddress
+import models.backend.{Site, UkAddress}
 import models.updateRegisteredDetails.ChangeRegisteredDetails
 import models.updateRegisteredDetails.ChangeRegisteredDetails.{BusinessAddress, ContactDetails, Sites}
+import models.{NormalMode, UserAnswers}
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.{convertToAnyMustWrapper, include}
 import pages.updateRegisteredDetails.{ChangeRegisteredDetailsPage, WarehouseDetailsPage}
@@ -67,7 +67,7 @@ class WarehouseDetailsControllerISpec extends ControllerITTestHelper {
             .commonPrecondition
 
           setAnswers(emptyUserAnswersForUpdateRegisteredDetails.copy(warehouseList =
-            Map("1" -> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy"), "WR53 7CX")))))
+            Map("1" -> Site(UkAddress(List("33 Rhes Priordy"), "WR53 7CX"), Some("ABC Ltd")))))
 
           WsTestClient.withClient { client =>
             val result1 = createClientRequestGet(client, updateRegisteredDetailsBaseUrl + normalRoutePath)

--- a/it/repositories/SessionRepositoryISpec.scala
+++ b/it/repositories/SessionRepositoryISpec.scala
@@ -1,7 +1,7 @@
 package repositories
 
 import models.backend.{Site, UkAddress}
-import models.{SelectChange, SmallProducer, UserAnswers, Warehouse}
+import models.{SelectChange, SmallProducer, UserAnswers}
 import org.mongodb.scala.bson.BsonDocument
 import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -74,7 +74,7 @@ class SessionRepositoryISpec
         Json.obj("foo" -> "bar"),
         List(SmallProducer("foo", "bar", (1,1))),
         Map("foo" -> Site(UkAddress(List("foo"),"foo", Some("foo")),Some("foo"), Some("foo"),Some(LocalDate.now()))),
-        Map("foo" -> Warehouse(Some("foo"),UkAddress(List("foo"),"foo", Some("foo")))),
+        Map("foo" -> Site(UkAddress(List("foo"),"foo", Some("foo")), Some("foo"))),
         UkAddress(List("123 Main Street", "Anytown"), "AB12 C34", alfId = Some("123456")),
         None,
         false,
@@ -99,7 +99,7 @@ class SessionRepositoryISpec
       }
       val warehouseListDecrypted = {
         val json = (resultParsedToJson \ "warehouseList").as[Map[String, EncryptedValue]]
-        json.map(warehouse => warehouse._1 -> Json.parse(encryption.crypto.decrypt(warehouse._2, userAnswersBefore.id)).as[Warehouse])
+        json.map(warehouse => warehouse._1 -> Json.parse(encryption.crypto.decrypt(warehouse._2, userAnswersBefore.id)).as[Site])
       }
       val contactAddressDecrypted = {
         Json.fromJson[Option[UkAddress]](Json.parse(encryption.crypto.decrypt((resultParsedToJson \ "contactAddress").as[EncryptedValue],

--- a/it/testSupport/ITCoreTestData.scala
+++ b/it/testSupport/ITCoreTestData.scala
@@ -35,7 +35,7 @@ trait ITCoreTestData
   def sdilNumber = "XKSDIL000000022"
   val producerName = Some("Super Cola Ltd")
 
-  val packAtBusinessAddressSite = Map("1" -> Site(UkAddress(List("63 Clifton Roundabout", "Worcester"), "WR53 7CX", None), None, Some("Super Lemonade Plc"), None))
+  val packAtBusinessAddressSite = Map("1" -> Site(UkAddress(List("63 Clifton Roundabout", "Worcester"), "WR53 7CX", None), Some("Super Lemonade Plc"), None, None))
 
   implicit val duration = 5.seconds
 

--- a/it/testSupport/ITCoreTestDataForChangeActivity.scala
+++ b/it/testSupport/ITCoreTestDataForChangeActivity.scala
@@ -1,7 +1,7 @@
 package testSupport
 
 import models.backend.Site
-import models.{SelectChange, UserAnswers, Warehouse}
+import models.{SelectChange, UserAnswers}
 import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import pages.changeActivity._
 import play.api.libs.json.Json
@@ -29,7 +29,7 @@ trait ITCoreTestDataForChangeActivity extends ITSharedCoreTestData {
   val filledUserAnswersForChangeActivityPackagingSiteDetailsPage: UserAnswers = {
     emptyUserAnswersForChangeActivity
       .set(PackagingSiteDetailsPage, true).success.value
-      .copy(packagingSiteList = Map("1" -> Site(ukAddress, None, None, None), "123456" -> Site(ukAddress, None, Some("Site two trading name"), None)))
+      .copy(packagingSiteList = Map("1" -> Site(ukAddress, None, None, None), "123456" -> Site(ukAddress, Some("Site two trading name"), None)))
       .set(SecondaryWarehouseDetailsPage, false).success.value
   }
 
@@ -52,11 +52,11 @@ trait ITCoreTestDataForChangeActivity extends ITSharedCoreTestData {
 
   def userAnswersForChangeActivityRemoveWarehouseDetailsPage(index: String): Map[String, UserAnswers] = {
     val yesSelected = emptyUserAnswersForChangeActivity
-      .copy(warehouseList = Map(index -> Warehouse(None, ukAddress)))
+      .copy(warehouseList = Map(index -> Site(ukAddress)))
       .set(RemoveWarehouseDetailsPage, true).success.value
 
     val noSelected = emptyUserAnswersForChangeActivity
-      .copy(warehouseList = Map(index -> Warehouse(None, ukAddress)))
+      .copy(warehouseList = Map(index -> Site(ukAddress)))
       .set(RemoveWarehouseDetailsPage, false).success.value
     Map("yes" -> yesSelected, "no" -> noSelected)
   }

--- a/it/testSupport/ITCoreTestDataForCorrectReturn.scala
+++ b/it/testSupport/ITCoreTestDataForCorrectReturn.scala
@@ -1,7 +1,7 @@
 package testSupport
 
 import models.backend.Site
-import models.{ReturnPeriod, SelectChange, UserAnswers, Warehouse}
+import models.{ReturnPeriod, SelectChange, UserAnswers}
 import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import pages.correctReturn._
 import play.api.libs.json.Json
@@ -27,11 +27,11 @@ trait ITCoreTestDataForCorrectReturn extends ITSharedCoreTestData  {
 
   def userAnswersForCorrectReturnRemoveWarehouseDetailsPage(index: String): Map[String, UserAnswers] = {
     val yesSelected = emptyUserAnswersForCorrectReturn
-      .copy(warehouseList = Map(index -> Warehouse(None, ukAddress)))
+      .copy(warehouseList = Map(index -> Site(ukAddress)))
       .set(RemoveWarehouseDetailsPage, true).success.value
 
     val noSelected = emptyUserAnswersForCorrectReturn
-      .copy(warehouseList = Map(index -> Warehouse(None, ukAddress)))
+      .copy(warehouseList = Map(index -> Site(ukAddress)))
       .set(RemoveWarehouseDetailsPage, false).success.value
     Map("yes" -> yesSelected, "no" -> noSelected)
   }

--- a/it/testSupport/ITCoreTestDataForUpdateRegisteredDetails.scala
+++ b/it/testSupport/ITCoreTestDataForUpdateRegisteredDetails.scala
@@ -2,20 +2,20 @@ package testSupport
 
 import models.backend.Site
 import models.updateRegisteredDetails.ContactDetails
-import models.{SelectChange, UserAnswers, Warehouse}
+import models.{SelectChange, UserAnswers}
 import org.scalatest.TryValues.convertTryToSuccessOrFailure
-import pages.updateRegisteredDetails.{ChangeRegisteredDetailsPage, PackagingSiteDetailsPage, PackingSiteDetailsRemovePage, RemoveWarehouseDetailsPage, WarehouseDetailsPage}
+import pages.updateRegisteredDetails.{PackagingSiteDetailsPage, PackingSiteDetailsRemovePage, RemoveWarehouseDetailsPage, WarehouseDetailsPage}
 import play.api.libs.json.Json
 
 trait ITCoreTestDataForUpdateRegisteredDetails extends ITSharedCoreTestData {
 
   def userAnswersForUpdateRegisteredDetailsRemoveWarehouseDetailsPage(index: String): Map[String, UserAnswers] = {
     val yesSelected = emptyUserAnswersForUpdateRegisteredDetails
-      .copy(warehouseList = Map(index -> Warehouse(None, ukAddress)))
+      .copy(warehouseList = Map(index -> Site(ukAddress)))
       .set(RemoveWarehouseDetailsPage, true).success.value
 
     val noSelected = emptyUserAnswersForUpdateRegisteredDetails
-      .copy(warehouseList = Map(index -> Warehouse(None, ukAddress)))
+      .copy(warehouseList = Map(index -> Site(ukAddress)))
       .set(RemoveWarehouseDetailsPage, false).success.value
     Map("yes" -> yesSelected, "no" -> noSelected)
   }

--- a/it/testSupport/ITSharedCoreTestData.scala
+++ b/it/testSupport/ITSharedCoreTestData.scala
@@ -1,6 +1,6 @@
 package testSupport
 
-import models.{SmallProducer, Warehouse}
+import models.SmallProducer
 import models.backend.{Site, UkAddress}
 
 trait ITSharedCoreTestData {
@@ -14,9 +14,9 @@ trait ITSharedCoreTestData {
     Some("Star Products Ltd"),
     None
   ))
-  val warehousesFromSubscription: Map[String, Warehouse] = Map(
-    "0" -> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy"),"WR53 7CX")),
-    "123456" -> Warehouse(Some("XYZ Ltd"), UkAddress(List("30 Main Street"), "WR53 7CX"))
+  val warehousesFromSubscription: Map[String, Site] = Map(
+    "0" -> Site(UkAddress(List("33 Rhes Priordy"),"WR53 7CX"), Some("ABC Ltd")),
+    "123456" -> Site(UkAddress(List("30 Main Street"), "WR53 7CX"), Some("XYZ Ltd"))
   )
 
   val smallProducersAddedList: List[SmallProducer] = List(

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -23,8 +23,8 @@ import controllers.actions._
 import controllers.routes
 import errors.VariationsErrors
 import helpers.LoggerHelper
-import models.{RetrievedActivity, _}
 import models.backend.{Site, UkAddress}
+import models.{RetrievedActivity, _}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -55,18 +55,18 @@ object SpecBase {
   val oneProductionSite: Map[String,Site] = Map(
    "1" -> Site(
       UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"),
-      Some("88"),
-      Some("Wild Lemonade Group"),
+     Some("Wild Lemonade Group"),
+     Some("88"),
       Some(LocalDate.of(2018, 2, 26)))
   )
 
-  val oneWarehouses: Map[String,Warehouse] = Map(
-    "1"-> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX"))
+  val oneWarehouses: Map[String,Site] = Map(
+    "1"-> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX"), Some("ABC Ltd"))
   )
 
-  val twoWarehouses: Map[String,Warehouse] = Map(
-    "1"-> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX")),
-    "2" -> Warehouse(Some("Super Cola Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE"))
+  val twoWarehouses: Map[String,Site] = Map(
+    "1"-> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX"), Some("ABC Ltd")),
+    "2" -> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE"), Some("Super Cola Ltd"))
   )
 
 

--- a/test/base/TestData.scala
+++ b/test/base/TestData.scala
@@ -99,9 +99,9 @@ trait TestData {
   val submittedDateTime = LocalDateTime.of(2023, 1, 1, 11, 0)
 
 
-  val twoWarehouses: Map[String, Warehouse] = Map(
-    "1" -> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy", "East London", "Line 3", "Line 4"), "WR53 7CX")),
-    "2" -> Warehouse(Some("Super Cola Ltd"), UkAddress(List("33 Rhes Priordy", "East London", "Line 3", ""), "SA13 7CE"))
+  val twoWarehouses: Map[String, Site] = Map(
+    "1" -> Site(UkAddress(List("33 Rhes Priordy", "East London", "Line 3", "Line 4"), "WR53 7CX"), Some("ABC Ltd")),
+    "2" -> Site(UkAddress(List("33 Rhes Priordy", "East London", "Line 3", ""), "SA13 7CE"), Some("Super Cola Ltd"))
   )
 
   val returnPeriodsFor2020 = List(ReturnPeriod(2020, 3), ReturnPeriod(2020, 2), ReturnPeriod(2020, 1), ReturnPeriod(2020, 0))
@@ -114,7 +114,7 @@ trait TestData {
     Json.toJson(ReturnPeriod(2022, 0)), Json.toJson(ReturnPeriod(2022, 1)),
     Json.toJson(ReturnPeriod(2022, 2)), Json.toJson(ReturnPeriod(2022, 3)))
 
-  lazy val warehouse = Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy"), "WR53 7CX"))
+  lazy val warehouse = Site(UkAddress(List("33 Rhes Priordy"), "WR53 7CX"), Some("ABC Ltd"))
   lazy val packingSite = Site(
     UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"),
     Some("88"),

--- a/test/connectors/SoftDrinksIndustryLevyConnectorSpec.scala
+++ b/test/connectors/SoftDrinksIndustryLevyConnectorSpec.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import base.SpecBase
-import models.{DataHelper, FinancialLineItem, Litreage, OptRetrievedSubscription, RetrievedSubscription, ReturnPeriod, SdilReturn, VariationsSubmission}
+import models.{DataHelper, FinancialLineItem, Litreage, OptRetrievedSubscription, RetrievedSubscription, ReturnPeriod, VariationsSubmission}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures

--- a/test/controllers/cancelRegistration/CancellationRequestDoneControllerSpec.scala
+++ b/test/controllers/cancelRegistration/CancellationRequestDoneControllerSpec.scala
@@ -21,9 +21,7 @@ import config.FrontendAppConfig
 import models.ReturnPeriod
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 import views.html.cancelRegistration.CancellationRequestDoneView
-import views.summary.updateRegisteredDetails.UpdateContactDetailsSummary
 
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDateTime, ZoneId}

--- a/test/controllers/changeActivity/ChangeActivityCYAControllerSpec.scala
+++ b/test/controllers/changeActivity/ChangeActivityCYAControllerSpec.scala
@@ -20,16 +20,14 @@ import base.SpecBase
 import connectors.SoftDrinksIndustryLevyConnector
 import controllers.changeActivity.routes._
 import generators.ChangeActivityCYAGenerators._
-import models.{DataHelper, Litreage, LitresInBands, VariationsSubmission}
 import models.SelectChange.ChangeActivity
 import models.changeActivity.AmountProduced.Large
-import navigation.{FakeNavigatorForChangeActivity, NavigatorForChangeActivity}
-import org.mockito.ArgumentMatchers.any
+import models.{DataHelper, Litreage, LitresInBands, VariationsSubmission}
 import org.mockito.Mockito.when
 import org.mockito.MockitoSugar.mock
-import pages.changeActivity.{AmountProducedPage, ContractPackingPage, HowManyContractPackingPage, HowManyImportsPage, HowManyOperatePackagingSiteOwnBrandsPage, ImportsPage}
-import play.api.mvc.Call
+import pages.changeActivity._
 import play.api.inject.bind
+import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.ChangeActivityService

--- a/test/controllers/changeActivity/RemovePackagingSiteDetailsControllerSpec.scala
+++ b/test/controllers/changeActivity/RemovePackagingSiteDetailsControllerSpec.scala
@@ -49,7 +49,7 @@ class RemovePackagingSiteDetailsControllerSpec extends SpecBase with MockitoSuga
   val addressOfPackingSite: UkAddress = UkAddress(List("foo"),"bar", None)
   val packingSiteTradingName: String = "a name for a packing site here"
   val userAnswersWithPackingSite: UserAnswers = emptyUserAnswersForChangeActivity
-    .copy(packagingSiteList = Map(indexOfPackingSiteToBeRemoved -> Site(addressOfPackingSite, None, Some(packingSiteTradingName), None)))
+    .copy(packagingSiteList = Map(indexOfPackingSiteToBeRemoved -> Site(addressOfPackingSite, Some(packingSiteTradingName), None, None)))
 
   "RemovePackagingSiteDetails Controller" - {
 

--- a/test/controllers/changeActivity/SecondaryWarehouseDetailsControllerSpec.scala
+++ b/test/controllers/changeActivity/SecondaryWarehouseDetailsControllerSpec.scala
@@ -20,8 +20,8 @@ import base.SpecBase
 import errors.SessionDatabaseInsertError
 import forms.changeActivity.SecondaryWarehouseDetailsFormProvider
 import models.SelectChange.ChangeActivity
-import models.backend.UkAddress
-import models.{UserAnswers, Warehouse}
+import models.UserAnswers
+import models.backend.{Site, UkAddress}
 import navigation._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers.any
@@ -109,7 +109,7 @@ class SecondaryWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar
     }
 
     "must populate the view correctly on a GET when the question has previously been answered with multiple warehouses in the list" in {
-      val warehouses = Map("1" -> warehouse, "2" -> Warehouse(Some("DEF Ltd"), UkAddress(List("34 Rhes Priordy"),"WR53 7CX")))
+      val warehouses = Map("1" -> warehouse, "2" -> Site(UkAddress(List("34 Rhes Priordy"),"WR53 7CX"), Some("DEF Ltd")))
       val summaryList = Some(SummaryListViewModel(rows = SecondaryWarehouseDetailsSummary.summaryRows(warehouses)))
 
       val userAnswers = UserAnswers(userAnswersId, ChangeActivity, warehouseList = warehouses, contactAddress = contactAddress)

--- a/test/controllers/correctReturn/CorrectReturnCheckChangesCYAControllerSpec.scala
+++ b/test/controllers/correctReturn/CorrectReturnCheckChangesCYAControllerSpec.scala
@@ -18,7 +18,6 @@ package controllers.correctReturn
 
 import base.SpecBase
 import controllers.correctReturn.routes._
-import models.SelectChange.CorrectReturn
 import models.correctReturn.{AddASmallProducer, ChangedPage, RepaymentMethod}
 import models.{LitresInBands, SmallProducer}
 import pages.correctReturn._

--- a/test/controllers/correctReturn/RemovePackagingSiteConfirmControllerSpec.scala
+++ b/test/controllers/correctReturn/RemovePackagingSiteConfirmControllerSpec.scala
@@ -49,7 +49,7 @@ class RemovePackagingSiteConfirmControllerSpec extends SpecBase with MockitoSuga
   val addressOfPackingSite: UkAddress = UkAddress(List("foo"),"bar", None)
   val packingSiteTradingName: String = "a name for a packing site here"
   val userAnswersWithPackingSite: UserAnswers = emptyUserAnswersForCorrectReturn
-    .copy(packagingSiteList = Map(indexOfPackingSiteToBeRemoved -> Site(addressOfPackingSite, None, Some(packingSiteTradingName), None)))
+    .copy(packagingSiteList = Map(indexOfPackingSiteToBeRemoved -> Site(addressOfPackingSite, Some(packingSiteTradingName), None, None)))
 
   "RemovePackagingSiteConfirm Controller" - {
 

--- a/test/controllers/correctReturn/RemoveWarehouseDetailsControllerSpec.scala
+++ b/test/controllers/correctReturn/RemoveWarehouseDetailsControllerSpec.scala
@@ -20,8 +20,8 @@ import base.SpecBase
 import errors.SessionDatabaseInsertError
 import forms.correctReturn.RemoveWarehouseDetailsFormProvider
 import models.SelectChange.CorrectReturn
-import models.backend.UkAddress
-import models.{NormalMode, UserAnswers, Warehouse}
+import models.backend.{Site, UkAddress}
+import models.{NormalMode, UserAnswers}
 import navigation._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -49,7 +49,7 @@ class RemoveWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar {
   val addressOfWarehouse: UkAddress = UkAddress(List("foo"),"bar", None)
   val warehouseTradingName: String = "a name for a warehouse here"
   val userAnswersWithWarehouse: UserAnswers = emptyUserAnswersForCorrectReturn
-    .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Warehouse(Some(warehouseTradingName), addressOfWarehouse)))
+    .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Site(addressOfWarehouse, Some(warehouseTradingName))))
 
   "RemoveWarehouseDetails Controller" - {
 

--- a/test/controllers/correctReturn/SecondaryWarehouseDetailsControllerSpec.scala
+++ b/test/controllers/correctReturn/SecondaryWarehouseDetailsControllerSpec.scala
@@ -17,10 +17,13 @@
 package controllers.correctReturn
 
 import base.SpecBase
+import errors.SessionDatabaseInsertError
 import forms.correctReturn.SecondaryWarehouseDetailsFormProvider
-import models.{NormalMode, Warehouse}
+import models.NormalMode
 import models.SelectChange.CorrectReturn
+import models.backend.{Site, UkAddress}
 import navigation._
+import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -30,18 +33,13 @@ import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.SessionService
-import views.html.correctReturn.SecondaryWarehouseDetailsView
-import utilities.GenericLogger
-import errors.SessionDatabaseInsertError
-import models.backend.UkAddress
-
-import scala.concurrent.Future
-import org.jsoup.Jsoup
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{SummaryList, SummaryListRow}
+import utilities.GenericLogger
 import viewmodels.govuk.SummaryListFluency
 import viewmodels.summary.correctReturn.SecondaryWarehouseDetailsSummary
+import views.html.correctReturn.SecondaryWarehouseDetailsView
 
-import scala.collection.immutable.Map
+import scala.concurrent.Future
 
 class SecondaryWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar with SummaryListFluency {
 
@@ -136,9 +134,9 @@ class SecondaryWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar
 
       running(application) {
 
-        val WarhouseMap: Map[String,Warehouse] =
-          Map("1"-> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX")),
-            "2" -> Warehouse(Some("Super Cola Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE")))
+        val WarhouseMap: Map[String,Site] =
+          Map("1"-> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX"), Some("ABC Ltd")),
+            "2" -> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE"), Some("Super Cola Ltd")))
 
         val warehouseSummaryList: List[SummaryListRow] =
           SecondaryWarehouseDetailsSummary.row2(WarhouseMap)(messages(application))

--- a/test/controllers/updateRegisteredDetails/PackingSiteDetailsRemoveControllerSpec.scala
+++ b/test/controllers/updateRegisteredDetails/PackingSiteDetailsRemoveControllerSpec.scala
@@ -49,7 +49,7 @@ class PackingSiteDetailsRemoveControllerSpec extends SpecBase with MockitoSugar 
   val addressOfPackingSite: UkAddress = UkAddress(List("foo"),"bar", None)
   val packingSiteTradingName: String = "a name for a packing site here"
   val userAnswersWithPackingSite: UserAnswers = emptyUserAnswersForUpdateRegisteredDetails
-    .copy(packagingSiteList = Map(indexOfPackingSiteToBeRemoved -> Site(addressOfPackingSite, None, Some(packingSiteTradingName), None)))
+    .copy(packagingSiteList = Map(indexOfPackingSiteToBeRemoved -> Site(addressOfPackingSite, Some(packingSiteTradingName), None, None)))
 
   "PackingSiteDetailsRemove Controller" - {
 

--- a/test/controllers/updateRegisteredDetails/RemoveWarehouseDetailsControllerSpec.scala
+++ b/test/controllers/updateRegisteredDetails/RemoveWarehouseDetailsControllerSpec.scala
@@ -20,8 +20,8 @@ import base.SpecBase
 import errors.SessionDatabaseInsertError
 import forms.updateRegisteredDetails.RemoveWarehouseDetailsFormProvider
 import models.SelectChange.UpdateRegisteredDetails
-import models.backend.UkAddress
-import models.{NormalMode, UserAnswers, Warehouse}
+import models.backend.{Site, UkAddress}
+import models.{NormalMode, UserAnswers}
 import navigation._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -49,7 +49,7 @@ class RemoveWarehouseDetailsControllerSpec extends SpecBase with MockitoSugar {
   val addressOfWarehouse: UkAddress = UkAddress(List("foo"),"bar", None)
   val warehouseTradingName: String = "a name for a warehouse here"
   val userAnswersWithWarehouse: UserAnswers = emptyUserAnswersForUpdateRegisteredDetails
-    .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Warehouse(Some(warehouseTradingName), addressOfWarehouse)))
+    .copy(warehouseList = Map(indexOfWarehouseToBeRemoved -> Site(addressOfWarehouse, Some(warehouseTradingName))))
 
   "RemoveWarehouseDetails Controller" - {
 

--- a/test/controllers/updateRegisteredDetails/WarehouseDetailsControllerSpec.scala
+++ b/test/controllers/updateRegisteredDetails/WarehouseDetailsControllerSpec.scala
@@ -20,9 +20,9 @@ import base.SpecBase
 import base.SpecBase.userAnswerTwoWarehousesUpdateRegisteredDetails
 import errors.SessionDatabaseInsertError
 import forms.updateRegisteredDetails.WarehouseDetailsFormProvider
-import models.{CheckMode, Mode, NormalMode}
 import models.SelectChange.UpdateRegisteredDetails
 import models.updateRegisteredDetails.ChangeRegisteredDetails
+import models.{CheckMode, Mode, NormalMode}
 import navigation._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -39,7 +39,6 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.SessionRepository
 import services.{AddressLookupService, SessionService, WarehouseDetails}
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{SummaryList, SummaryListRow}
 import utilities.GenericLogger
 import viewmodels.govuk.SummaryListFluency
 import views.html.updateRegisteredDetails.WarehouseDetailsView
@@ -71,15 +70,6 @@ class WarehouseDetailsControllerSpec extends SpecBase with MockitoSugar with Sum
           val request = FakeRequest(GET, warehouseDetailsRouteForMode(mode))
 
           val result = route(application, request).value
-
-          val view = application.injector.instanceOf[WarehouseDetailsView]
-
-          val warehouseSummaryList: List[SummaryListRow] =
-            WarehouseDetailsSummary.row2(twoWarehouses, mode)(messages(application))
-
-          val summaryList: SummaryList = SummaryListViewModel(
-            rows = warehouseSummaryList
-          )
 
           status(result) mustEqual OK
           val summaryActions = doc(contentAsString(result)).getElementsByClass("govuk-summary-list__actions")

--- a/test/models/DataHelper.scala
+++ b/test/models/DataHelper.scala
@@ -154,7 +154,7 @@ trait DataHelper {
   def testWarehouse(
                      tradingName: String = "test trading name",
                      address: UkAddress
-                   ): Warehouse = Warehouse(
+                   ): Site = Site(
     tradingName = Some(tradingName),
     address = address
   )

--- a/test/models/ModelEncryptionSpec.scala
+++ b/test/models/ModelEncryptionSpec.scala
@@ -35,7 +35,7 @@ class ModelEncryptionSpec extends SpecBase {
         Json.obj("foo" -> "bar"),
         List(SmallProducer("foo", "bar", (1,1))),
         Map("foo" -> Site(UkAddress(List("foo"),"foo", Some("foo")),Some("foo"), Some("foo"),Some(LocalDate.now()))),
-        Map("foo" -> Warehouse(Some("foo"),UkAddress(List("foo"),"foo", Some("foo")))),
+        Map("foo" -> Site(UkAddress(List("foo"),"foo", Some("foo")), Some("foo"))),
         UkAddress(List("123 Main Street", "Anytown"), "AB12 C34", alfId = Some("123456")),
         None,
         false,
@@ -49,7 +49,7 @@ class ModelEncryptionSpec extends SpecBase {
       Json.parse(encryption.crypto.decrypt(result._4, userAnswers.id)).as[List[SmallProducer]] mustBe userAnswers.smallProducerList
       Json.parse(encryption.crypto.decrypt(result._5.head._2, userAnswers.id)).as[Site] mustBe userAnswers.packagingSiteList.head._2
       result._5.head._1 mustBe userAnswers.packagingSiteList.head._1
-      Json.parse(encryption.crypto.decrypt(result._6.head._2, userAnswers.id)).as[Warehouse] mustBe userAnswers.warehouseList.head._2
+      Json.parse(encryption.crypto.decrypt(result._6.head._2, userAnswers.id)).as[Site] mustBe userAnswers.warehouseList.head._2
       result._6.head._1 mustBe userAnswers.warehouseList.head._1
       Json.parse(encryption.crypto.decrypt(result._7, userAnswers.id)).as[UkAddress] mustBe userAnswers.contactAddress
       result._9 mustBe userAnswers.submitted
@@ -64,7 +64,7 @@ class ModelEncryptionSpec extends SpecBase {
         Json.obj("foo" -> "bar"),
         List(SmallProducer("foo", "bar", (1,1))),
         Map("foo" -> Site(UkAddress(List("foo"),"foo", Some("foo")),Some("foo"), Some("foo"),Some(LocalDate.now()))),
-        Map("foo" -> Warehouse(Some("foo"),UkAddress(List("foo"),"foo", Some("foo")))),
+        Map("foo" -> Site(UkAddress(List("foo"),"foo", Some("foo")), Some("foo"))),
         UkAddress(List("123 Main Street", "Anytown"), "AB12 C34", alfId = Some("123456")), Some(ReturnPeriod(2023, 1)),
         false,
         Option(Instant.ofEpochSecond(1)),

--- a/test/orchestrators/SelectChangeOrchestratorSpec.scala
+++ b/test/orchestrators/SelectChangeOrchestratorSpec.scala
@@ -21,7 +21,7 @@ import connectors.SoftDrinksIndustryLevyConnector
 import errors.{ReturnsStillPending, SessionDatabaseInsertError, UnexpectedResponseFromSDIL}
 import models.backend.{Site, UkAddress}
 import models.updateRegisteredDetails.ContactDetails
-import models.{Contact, RetrievedActivity, RetrievedSubscription, SelectChange, UserAnswers, Warehouse}
+import models.{Contact, RetrievedActivity, RetrievedSubscription, SelectChange, UserAnswers}
 import org.mockito.MockitoSugar.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
@@ -78,7 +78,7 @@ class SelectChangeOrchestratorSpec extends SpecBase with MockitoSugar {
 
   def expectedUserAnswers(value: SelectChange,
                           productionSites: Map[String, Site] = Map.empty,
-                          warehouses: Map[String, Warehouse] = Map.empty,
+                          warehouses: Map[String, Site] = Map.empty,
                           addContactDetails: Boolean = false): UserAnswers = {
     val data = if(addContactDetails) {
       Json.obj(("updateRegisteredDetails", Json.obj(("updateContactDetails", Json.toJson(updateContact)))))
@@ -157,21 +157,19 @@ class SelectChangeOrchestratorSpec extends SpecBase with MockitoSugar {
           }
 
           "when the subscription contains packaging sites and warehouses that have no or closure dates in the future" in {
-            val packagingSite1 = Site(address1, None, Some(tradingName1), None)
-            val packagingSite2 = Site(address2, None, Some(tradingName2), Some(LocalDate.now().plusYears(2L)))
+            val packagingSite1 = Site(address1, Some(tradingName1), None, None)
+            val packagingSite2 = Site(address2, Some(tradingName2), None, Some(LocalDate.now().plusYears(2L)))
             val packagingSites = List(packagingSite1, packagingSite2)
-            val warehouseSite1 = Site(address3, None, Some(tradingName3), None)
-            val warehouseSite2 = Site(address4, None, Some(tradingName4), Some(LocalDate.now().plusYears(2L)))
+            val warehouseSite1 = Site(address3, Some(tradingName3), None, None)
+            val warehouseSite2 = Site(address4, Some(tradingName4), None, Some(LocalDate.now().plusYears(2L)))
             val warehouseSites = List(warehouseSite1, warehouseSite2)
-            val warehouse1 = Warehouse(Some(tradingName3), address3)
-            val warehouse2 = Warehouse(Some(tradingName4), address4)
             if (selectChange == SelectChange.CancelRegistration) {
               when(mockSdilConnector.returnsPending("0000000022")(hc))
                 .thenReturn(createSuccessVariationResult(List.empty))
             }
             val expectedGeneratedUA = expectedUserAnswers(selectChange,
               Map("0" -> packagingSite1, "1" -> packagingSite2),
-              Map("0" -> warehouse1, "1" -> warehouse2),
+              Map("0" -> warehouseSite1, "1" -> warehouseSite2),
               addContactDetails = selectChange == SelectChange.UpdateRegisteredDetails)
             when(mockSessionService.set(expectedGeneratedUA)).thenReturn(Future.successful(Right(true)))
 
@@ -183,13 +181,13 @@ class SelectChangeOrchestratorSpec extends SpecBase with MockitoSugar {
           }
 
           "when the subscription contains packaging sites and warehouses that have one closure date in the past" in {
-            val packagingSite1 = Site(address1, None, Some(tradingName1), None)
-            val packagingSite2 = Site(address2, None, Some(tradingName2), Some(LocalDate.now().minusYears(2L)))
+            val packagingSite1 = Site(address1, Some(tradingName1), None, None)
+            val packagingSite2 = Site(address2, Some(tradingName2), None, Some(LocalDate.now().minusYears(2L)))
             val packagingSites = List(packagingSite1, packagingSite2)
-            val warehouseSite1 = Site(address3, None, Some(tradingName3), None)
-            val warehouseSite2 = Site(address4, None, Some(tradingName4), Some(LocalDate.now().minusYears(2L)))
+            val warehouseSite1 = Site(address3, Some(tradingName3), None, None)
+            val warehouseSite2 = Site(address4, Some(tradingName4), None, Some(LocalDate.now().minusYears(2L)))
             val warehouseSites = List(warehouseSite1, warehouseSite2)
-            val warehouse1 = Warehouse(Some(tradingName3), address3)
+            val warehouse1 = Site(address3, Some(tradingName3))
             if (selectChange == SelectChange.CancelRegistration) {
               when(mockSdilConnector.returnsPending("0000000022")(hc))
                 .thenReturn(createSuccessVariationResult(List.empty))
@@ -254,17 +252,15 @@ class SelectChangeOrchestratorSpec extends SpecBase with MockitoSugar {
       }
 
       "when the subscription contains packaging sites and warehouses that have no or closure dates in the future" in {
-        val packagingSite1 = Site(address1, None, Some(tradingName1), None)
-        val packagingSite2 = Site(address2, None, Some(tradingName2), Some(LocalDate.now().plusYears(2L)))
+        val packagingSite1 = Site(address1, Some(tradingName1), None, None)
+        val packagingSite2 = Site(address2, Some(tradingName2), None, Some(LocalDate.now().plusYears(2L)))
         val packagingSites = List(packagingSite1, packagingSite2)
-        val warehouseSite1 = Site(address3, None, Some(tradingName3), None)
-        val warehouseSite2 = Site(address4, None, Some(tradingName4), Some(LocalDate.now().plusYears(2L)))
+        val warehouseSite1 = Site(address3, Some(tradingName3), None, None)
+        val warehouseSite2 = Site(address4, Some(tradingName4), None, Some(LocalDate.now().plusYears(2L)))
         val warehouseSites = List(warehouseSite1, warehouseSite2)
-        val warehouse1 = Warehouse(Some(tradingName3), address3)
-        val warehouse2 = Warehouse(Some(tradingName4), address4)
         val expectedGeneratedUA = expectedUserAnswers(SelectChange.CorrectReturn,
           Map("0" -> packagingSite1, "1" -> packagingSite2),
-          Map("0" -> warehouse1, "1" -> warehouse2))
+          Map("0" -> warehouseSite1, "1" -> warehouseSite2))
         when(mockSessionService.set(expectedGeneratedUA)).thenReturn(Future.successful(Right(true)))
 
         val res = orchestrator.createCorrectReturnUserAnswersForDeregisteredUserAndSaveToDatabase(retrievedSubscription(packagingSites, warehouseSites, deregDate = Some(LocalDate.now)))
@@ -275,13 +271,13 @@ class SelectChangeOrchestratorSpec extends SpecBase with MockitoSugar {
       }
 
       "when the subscription contains packaging sites and warehouses that have one closure date in the past" in {
-        val packagingSite1 = Site(address1, None, Some(tradingName1), None)
-        val packagingSite2 = Site(address2, None, Some(tradingName2), Some(LocalDate.now().minusYears(2L)))
+        val packagingSite1 = Site(address1, Some(tradingName1), None, None)
+        val packagingSite2 = Site(address2, Some(tradingName2), None, Some(LocalDate.now().minusYears(2L)))
         val packagingSites = List(packagingSite1, packagingSite2)
-        val warehouseSite1 = Site(address3, None, Some(tradingName3), None)
-        val warehouseSite2 = Site(address4, None, Some(tradingName4), Some(LocalDate.now().minusYears(2L)))
+        val warehouseSite1 = Site(address3, Some(tradingName3), None, None)
+        val warehouseSite2 = Site(address4, Some(tradingName4), None, Some(LocalDate.now().minusYears(2L)))
         val warehouseSites = List(warehouseSite1, warehouseSite2)
-        val warehouse1 = Warehouse(Some(tradingName3), address3)
+        val warehouse1 = Site(address3, Some(tradingName3))
         val expectedGeneratedUA = expectedUserAnswers(SelectChange.CorrectReturn,
           Map("0" -> packagingSite1),
           Map("0" -> warehouse1))

--- a/test/services/AddressLookupServiceSpec.scala
+++ b/test/services/AddressLookupServiceSpec.scala
@@ -19,7 +19,6 @@ package services
 import base.SpecBase
 import connectors.AddressLookupConnector
 import controllers.routes
-import models.Warehouse
 import models.alf.init._
 import models.alf.{AlfAddress, AlfResponse}
 import models.backend.{Site, UkAddress}
@@ -72,10 +71,10 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
       val addressLookupState = WarehouseDetails
       val sdilId: String = "foo"
       val alfId: String = "bar"
-      val warehouseMap = Map("1" -> Warehouse(Some("super cola"), UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP")))
+      val warehouseMap = Map("1" -> Site(UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"), Some("super cola")))
       val addedWarehouse = Map(
-        "1" -> Warehouse(Some("super cola"), UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP")),
-        sdilId -> Warehouse(Some(organisation), UkAddress(List(addressLine1, addressLine2, addressLine3, addressLine4), postcode, alfId = Some(alfId))))
+        "1" -> Site(UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"), Some("super cola")),
+        sdilId -> Site(UkAddress(List(addressLine1, addressLine2, addressLine3, addressLine4), postcode, alfId = Some(alfId)), Some(organisation)))
 
       val res = service.addAddressUserAnswers(addressLookupState = addressLookupState,
         address = customerAddressMax.address,
@@ -90,9 +89,9 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
       val sdilId: String = "foo"
       val alfId: String = "bar"
       val warehouseMap = Map(sdilId ->
-        Warehouse(Some("super cola"), UkAddress(List("foo", "bar"), "wizz")))
+        Site(UkAddress(List("foo", "bar"), "wizz"), Some("super cola")))
       val updatedWarehouseMap = Map(sdilId ->
-        Warehouse(Some("soft drinks ltd"), UkAddress(List("line 1", "line 2", "line 3", "line 4"), "aa1 1aa", alfId = Some(alfId))))
+        Site(UkAddress(List("line 1", "line 2", "line 3", "line 4"), "aa1 1aa", alfId = Some(alfId)), Some("soft drinks ltd")))
 
       val res = service.addAddressUserAnswers(addressLookupState = addressLookupState,
         address = customerAddressMax.address,
@@ -107,9 +106,9 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
       val addressLookupState = WarehouseDetails
       val sdilId: String = "foo"
       val alfId: String = "bar"
-      val warehouseMap = Map("1" -> Warehouse(Some("super cola"), UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP")))
-      val addedWarehouseMissingLines = Map("1" -> Warehouse(Some("super cola"), UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP")),
-        sdilId -> Warehouse(Some(organisation), UkAddress(List(addressLine1, addressLine2), postcode, alfId = Some(alfId))))
+      val warehouseMap = Map("1" -> Site(UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"), Some("super cola")))
+      val addedWarehouseMissingLines = Map("1" -> Site(UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"), Some("super cola")),
+        sdilId -> Site(UkAddress(List(addressLine1, addressLine2), postcode, alfId = Some(alfId)), Some(organisation)))
       val customerAddressMissingLines: AlfAddress =
         AlfAddress(
           Some(organisation),
@@ -131,7 +130,7 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
       val addressLookupState = WarehouseDetails
       val sdilId: String = "foo"
       val alfId: String = "bar"
-      val warehouseMap = Map("1" -> Warehouse(Some("super cola"), UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP")))
+      val warehouseMap = Map("1" -> Site(UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"), Some("super cola")))
 
       val res = service.addAddressUserAnswers(addressLookupState = addressLookupState,
         address = AlfAddress(Some(organisation),
@@ -143,10 +142,10 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
         alfId = alfId,
         sdilId = sdilId)
 
-      res.warehouseList mustBe Map("1" -> Warehouse(Some("super cola"),
-        UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP")),
-        sdilId -> Warehouse(Some(organisation),
-          UkAddress(List(addressLine1, addressLine2, addressLine3, addressLine4), postcode, alfId = Some(alfId))))
+      res.warehouseList mustBe Map("1" -> Site(
+        UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"), Some("super cola")),
+        sdilId -> Site(
+          UkAddress(List(addressLine1, addressLine2, addressLine3, addressLine4), postcode, alfId = Some(alfId)), Some(organisation)))
     }
 
     s"add to the cache the address of a $PackingDetails when a user returns from address lookup frontend with missing address lines" in {
@@ -242,7 +241,7 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
 
     "don't add to userAnswers when no details are added in alf and throw exception" in {
       val addressLookupState = WarehouseDetails
-      val warehouseMap = Map("1" -> Warehouse(Some("super cola"), UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP")))
+      val warehouseMap = Map("1" -> Site(UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"), Some("super cola")))
       val customerAddressMissingLinesAndName: AlfAddress = AlfAddress(
         None,
         List(),

--- a/test/views/correctReturn/PackagingSiteDetailsViewSpec.scala
+++ b/test/views/correctReturn/PackagingSiteDetailsViewSpec.scala
@@ -238,13 +238,13 @@ class PackagingSiteDetailsViewSpec extends ViewSpecHelper {
   "View should contain the correct heading and summary row details" - {
     lazy val pSite = Site(
       UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"),
-      Some("88"),
       Some("Wild Lemonade Group"),
+      Some("88"),
       Some(LocalDate.of(2018, 2, 26)))
     lazy val pSite2 = Site(
       UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"),
-      Some("88"),
       None,
+      Some("88"),
       Some(LocalDate.of(2018, 2, 26)))
     lazy val packagingSites2 = Map("000001" -> pSite, "00002" -> pSite2)
     lazy val packagingSites = Map("00213" -> pSite)

--- a/test/views/correctReturn/SecondaryWarehouseDetailsViewSpec.scala
+++ b/test/views/correctReturn/SecondaryWarehouseDetailsViewSpec.scala
@@ -18,8 +18,8 @@ package views.correctReturn
 
 import controllers.correctReturn.routes
 import forms.correctReturn.SecondaryWarehouseDetailsFormProvider
-import models.backend.UkAddress
-import models.{CheckMode, NormalMode, Warehouse}
+import models.backend.{Site, UkAddress}
+import models.{CheckMode, NormalMode}
 import play.api.data.Form
 import play.api.i18n.Messages
 import play.api.mvc.Request
@@ -51,9 +51,9 @@ class SecondaryWarehouseDetailsViewSpec extends ViewSpecHelper with SummaryListF
   }
 
   "View" - {
-    val WarehouseMap: Map[String,Warehouse] =
-      Map("1"-> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX")),
-        "2" -> Warehouse(Some("Super Cola Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE")))
+    val WarehouseMap: Map[String,Site] =
+      Map("1"-> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX"), Some("ABC Ltd")),
+        "2" -> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE"), Some("Super Cola Ltd")))
 
     val warehouseSummaryList: List[SummaryListRow] =
       SecondaryWarehouseDetailsSummary.row2(WarehouseMap)(messages(application))
@@ -110,9 +110,9 @@ class SecondaryWarehouseDetailsViewSpec extends ViewSpecHelper with SummaryListF
     }
 
     "when the form is preoccupied with yes and has no errors" - {
-      val WarehouseMap: Map[String,Warehouse] =
-        Map("1"-> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX")),
-          "2" -> Warehouse(Some("Super Cola Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE")))
+      val WarehouseMap: Map[String,Site] =
+        Map("1"-> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX"), Some("ABC Ltd")),
+          "2" -> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE"), Some("Super Cola Ltd")))
 
       val warehouseSummaryList: List[SummaryListRow] =
         SecondaryWarehouseDetailsSummary.row2(WarehouseMap)(messages(application))
@@ -156,9 +156,9 @@ class SecondaryWarehouseDetailsViewSpec extends ViewSpecHelper with SummaryListF
     }
 
     "when the form is preoccupied with no and has no errors" - {
-      val WarehouseMap: Map[String,Warehouse] =
-        Map("1"-> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX")),
-          "2" -> Warehouse(Some("Super Cola Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE")))
+      val WarehouseMap: Map[String,Site] =
+        Map("1"-> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX"), Some("ABC Ltd")),
+          "2" -> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE"), Some("Super Cola Ltd")))
 
       val warehouseSummaryList: List[SummaryListRow] =
         SecondaryWarehouseDetailsSummary.row2(WarehouseMap)(messages(application))
@@ -207,9 +207,9 @@ class SecondaryWarehouseDetailsViewSpec extends ViewSpecHelper with SummaryListF
 
     "contains a form with the correct action" - {
       "when in CheckMode" - {
-        val WarhouseMap: Map[String,Warehouse] =
-          Map("1"-> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX")),
-            "2" -> Warehouse(Some("Super Cola Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE")))
+        val WarhouseMap: Map[String,Site] =
+          Map("1"-> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX"), Some("ABC Ltd")),
+            "2" -> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE"), Some("Super Cola Ltd")))
 
         val warehouseSummaryList: List[SummaryListRow] =
           SecondaryWarehouseDetailsSummary.row2(WarhouseMap)(messages(application))
@@ -236,9 +236,9 @@ class SecondaryWarehouseDetailsViewSpec extends ViewSpecHelper with SummaryListF
       }
 
       "when in NormalMode" - {
-        val WarhouseMap: Map[String,Warehouse] =
-          Map("1"-> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX")),
-            "2" -> Warehouse(Some("Super Cola Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE")))
+        val WarhouseMap: Map[String,Site] =
+          Map("1"-> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX"), Some("ABC Ltd")),
+            "2" -> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE"), Some("Super Cola Ltd")))
 
         val warehouseSummaryList: List[SummaryListRow] =
           SecondaryWarehouseDetailsSummary.row2(WarhouseMap)(messages(application))
@@ -265,9 +265,9 @@ class SecondaryWarehouseDetailsViewSpec extends ViewSpecHelper with SummaryListF
     }
 
     "when there are form errors" - {
-      val WarehouseMap: Map[String,Warehouse] =
-        Map("1"-> Warehouse(Some("ABC Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX")),
-          "2" -> Warehouse(Some("Super Cola Ltd"), UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE")))
+      val WarehouseMap: Map[String,Site] =
+        Map("1"-> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3","Line 4"),"WR53 7CX"), Some("ABC Ltd")),
+          "2" -> Site(UkAddress(List("33 Rhes Priordy", "East London","Line 3",""),"SA13 7CE"), Some("Super Cola Ltd")))
 
       val warehouseSummaryList: List[SummaryListRow] =
         SecondaryWarehouseDetailsSummary.row2(WarehouseMap)(messages(application))

--- a/test/views/summary/correctReturn/CorrectReturnCheckChangesSummarySpec.scala
+++ b/test/views/summary/correctReturn/CorrectReturnCheckChangesSummarySpec.scala
@@ -17,7 +17,7 @@
 package views.summary.correctReturn
 
 import base.SpecBase
-import models.correctReturn.{AddASmallProducer, ChangedPage, RepaymentMethod}
+import models.correctReturn.{AddASmallProducer, RepaymentMethod}
 import models.{LitresInBands, SmallProducer}
 import pages.correctReturn._
 

--- a/test/views/summary/correctReturn/PackagingSiteDetailsSummarySpec.scala
+++ b/test/views/summary/correctReturn/PackagingSiteDetailsSummarySpec.scala
@@ -24,13 +24,13 @@ import java.time.LocalDate
 class PackagingSiteDetailsSummarySpec extends SpecBase {
   lazy val pSite: Site = Site(
     UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"),
-    Some("88"),
     Some("Wild Lemonade Group"),
+    Some("88"),
     Some(LocalDate.of(2018, 2, 26)))
   lazy val pSite2: Site = Site(
     UkAddress(List("33 Rhes Priordy", "East London"), "E73 2RP"),
-    Some("88"),
     None,
+    Some("88"),
     Some(LocalDate.of(2018, 2, 26)))
   lazy val packagingSites2: Map[String, Site] = Map("000001" -> pSite, "00002" -> pSite2)
   lazy val packagingSite1: Map[String, Site] = Map("00213" -> pSite)


### PR DESCRIPTION
This PR is just removing the Warehouse case class and instead using the Site given they are pretty much the same. It will make the site comparison easier and save the converting back and forth.