### PR TITLE
DLS-9317 update to change registration in return controller & navigator for Correct Return

### DIFF
--- a/app/controllers/correctReturn/ReturnChangeRegistrationController.scala
+++ b/app/controllers/correctReturn/ReturnChangeRegistrationController.scala
@@ -38,12 +38,11 @@ class ReturnChangeRegistrationController @Inject()(
 
   def onPageLoad(mode: Mode): Action[AnyContent] = controllerActions.withCorrectReturnJourneyData {
     implicit request =>
-      val userIsOnlyANewImporter = UserTypeCheck.isNewImporter(SdilReturn.apply(request.userAnswers), request.subscription) &&
-        !UserTypeCheck.isNewPacker(SdilReturn.apply(request.userAnswers), request.subscription)
-      if (userIsOnlyANewImporter) {
-        Ok(view(mode, controllers.correctReturn.routes.BroughtIntoUKController.onPageLoad(mode).url))
-      } else {
+        val userIsANewPacker = UserTypeCheck.isNewPacker(SdilReturn.apply(request.userAnswers), request.subscription)
+      if (userIsANewPacker) {
         Ok(view(mode, controllers.correctReturn.routes.PackagedAsContractPackerController.onPageLoad(mode).url))
+      } else {
+        Ok(view(mode, controllers.correctReturn.routes.BroughtIntoUKController.onPageLoad(mode).url))
       }
   }
 

--- a/app/utilities/UserTypeCheck.scala
+++ b/app/utilities/UserTypeCheck.scala
@@ -22,9 +22,11 @@ import models.backend.RetrievedSubscription
 
 object UserTypeCheck {
   def isNewImporter(sdilReturn: SdilReturn,subscription: RetrievedSubscription): Boolean = {
-  (sdilReturn.totalImported._1 > 0L && sdilReturn.totalImported._2 > 0L) && !subscription.activity.importer
+    val userIsNotAlreadyAnImporter = !subscription.activity.importer
+    (sdilReturn.totalImported._1 > 0L && sdilReturn.totalImported._2 > 0L) && userIsNotAlreadyAnImporter
 }
   def isNewPacker(sdilReturn: SdilReturn, subscription: RetrievedSubscription): Boolean = {
-    (sdilReturn.totalPacked._1 > 0L && sdilReturn.totalPacked._2 > 0L) && !subscription.activity.contractPacker
+    val userIsNotAlreadyAPacker = !subscription.activity.contractPacker
+    (sdilReturn.totalPacked._1 > 0L && sdilReturn.totalPacked._2 > 0L) && userIsNotAlreadyAPacker
   }
 }

--- a/test/base/TestData.scala
+++ b/test/base/TestData.scala
@@ -183,8 +183,8 @@ trait TestData {
     sdilRef = "XKSDIL000000023", activity = RetrievedActivity(
     smallProducer = false, largeProducer = true, contractPacker = true, importer = true, voluntaryRegistration = false))
 
-  def completedUserAnswersForCorrectReturnNewPackerOrImporter: UserAnswers = UserAnswers(changedUserSdilNumber, SelectChange.CorrectReturn,
-    Json.obj(), packagingSiteList = Map.empty, warehouseList = Map.empty, contactAddress = updatedContactAddress,
+  def completedUserAnswersForCorrectReturnNewPackerOrImporter: UserAnswers = userAnswersForCorrectReturnWithEmptySdilReturn.copy(id = changedUserSdilNumber,
+    packagingSiteList = Map.empty, warehouseList = Map.empty, contactAddress = updatedContactAddress,
     correctReturnPeriod = Some(ReturnPeriod(2023, 0)))
     .set(OperatePackagingSiteOwnBrandsPage, true).success.value
     .set(HowManyOperatePackagingSiteOwnBrandsPage, LitresInBands(32432, 34839)).success.value

--- a/test/navigation/NavigatorForCorrectReturnSpec.scala
+++ b/test/navigation/NavigatorForCorrectReturnSpec.scala
@@ -454,6 +454,45 @@ class NavigatorForCorrectReturnSpec extends SpecBase with DataHelper {
     }
   }
 
+  "Return change registration page " - {
+    def navigateFromReturnChangeRegistrationPageWhenNewImporter(mode: Mode, subscription: Option[RetrievedSubscription] = Some(aSubscription)) =
+      navigator.nextPage(ReturnChangeRegistrationPage, mode, completedUserAnswersForCorrectReturnNewPackerOrImporter
+        .set(PackagedAsContractPackerPage, false).success.value, subscription)
+
+    def navigateFromReturnChangeRegistrationPageWhenNewCoPacker(mode: Mode, subscription: Option[RetrievedSubscription] = Some(aSubscription)) =
+      navigator.nextPage(ReturnChangeRegistrationPage, mode, completedUserAnswersForCorrectReturnNewPackerOrImporter, subscription)
+
+    "should navigate to Ask Secondary Warehouse in return when the user is a new importer with no warehouses in NormalMode" in {
+      val result = navigateFromReturnChangeRegistrationPageWhenNewImporter(NormalMode, Some(aSubscription))
+      result mustBe routes.AskSecondaryWarehouseInReturnController.onPageLoad(NormalMode)
+    }
+
+    "should navigate to Pack At Business Address when the user is a new packer with no packaging sites in NormalMode" in {
+      val result = navigateFromReturnChangeRegistrationPageWhenNewCoPacker(NormalMode, Some(aSubscription))
+      result mustBe routes.PackAtBusinessAddressController.onPageLoad(NormalMode)
+    }
+
+    def navigateFromReturnChangeRegistrationPageWhenNewImporterButUserHasSites(mode: Mode, subscription: Option[RetrievedSubscription] = Some(aSubscription)) =
+      navigator.nextPage(ReturnChangeRegistrationPage, mode, completedUserAnswersForCorrectReturnNewPackerOrImporter
+        .copy(warehouseList = twoWarehouses)
+        .set(PackagedAsContractPackerPage, false).success.value, subscription)
+
+    def navigateFromReturnChangeRegistrationPageWhenNewCoPackerButUserHasSites(mode: Mode, subscription: Option[RetrievedSubscription] = Some(aSubscription)) =
+      navigator.nextPage(ReturnChangeRegistrationPage, mode, completedUserAnswersForCorrectReturnNewPackerOrImporter
+        .copy(packagingSiteList = packingSiteMap)
+        .set(BroughtIntoUKPage, false).success.value, subscription)
+
+    "should navigate to Check your answers when the user is a new importer with existing warehouses in NormalMode" in {
+      val result = navigateFromReturnChangeRegistrationPageWhenNewImporterButUserHasSites(NormalMode, Some(aSubscription))
+      result mustBe routes.CorrectReturnCYAController.onPageLoad
+    }
+
+    "should navigate to Check your answers when the user is a new packer with existing packaging sites in NormalMode" in {
+      val result = navigateFromReturnChangeRegistrationPageWhenNewCoPackerButUserHasSites(NormalMode, Some(aSubscription))
+      result mustBe routes.CorrectReturnCYAController.onPageLoad
+    }
+  }
+
   "Packaging Site Details " - {
     def navigateFromPackagingSiteDetailsPage(mode: Mode, subscription: Option[RetrievedSubscription] = None) =
       navigator.nextPage(PackagingSiteDetailsPage, mode,

--- a/test/views/correctReturn/ReturnChangeRegistrationViewSpec.scala
+++ b/test/views/correctReturn/ReturnChangeRegistrationViewSpec.scala
@@ -17,6 +17,7 @@
 package views.correctReturn
 
 import models.NormalMode
+import org.jsoup.Jsoup
 import play.api.i18n.Messages
 import play.api.mvc.Request
 import play.api.test.FakeRequest
@@ -25,7 +26,7 @@ import views.html.correctReturn.ReturnChangeRegistrationView
 
 class ReturnChangeRegistrationViewSpec extends ViewSpecHelper {
 
-  val view = application.injector.instanceOf[ReturnChangeRegistrationView]
+  val view: ReturnChangeRegistrationView = application.injector.instanceOf[ReturnChangeRegistrationView]
   implicit val request: Request[_] = FakeRequest()
 
   object Selectors {
@@ -41,6 +42,39 @@ class ReturnChangeRegistrationViewSpec extends ViewSpecHelper {
 
     "should have the expected heading" in {
       document.getElementsByClass(Selectors.heading).text() mustEqual Messages("You changed your soft drinks business activity")
+    }
+
+    "should render correctly with Packaged Contract Packer link when coPacker is false but coPacker data was completed" in {
+      val urlLink: String = controllers.correctReturn.routes.PackagedAsContractPackerController.onPageLoad(NormalMode).url
+      val renderedView = Jsoup.parse(view(NormalMode, urlLink)(FakeRequest(), implicitly).body)
+      renderedView.title() mustBe "You changed your soft drinks business activity - Soft Drinks Industry Levy - GOV.UK"
+      renderedView.getElementsByTag("h1").text() mustBe "You changed your soft drinks business activity"
+      renderedView.getElementsByTag("h1").attr("class") mustBe "govuk-heading-l"
+      val bodyText = renderedView.getElementsByClass("govuk-body").eachText()
+      bodyText.get(0) mustBe "In this return, you told us that you have packaged liable drinks in the UK."
+      bodyText.get(1) mustBe "This is different to your registered business activity, so we will update your registration."
+      bodyText.get(2) mustBe "If you made a mistake, you need to go back and change your answers."
+      bodyText.get(3) mustBe "If you’re happy with the change, select Update Registration."
+      renderedView.getElementsByTag("button").first().text() mustBe "Update registration"
+      val linkInBodyText = renderedView.getElementById("main-content").getElementsByTag("a")
+      linkInBodyText.attr("href") mustBe "/soft-drinks-industry-levy-variations-frontend/correct-return/packaged-as-contract-packer"
+    }
+
+    "should render correctly with Brought into UK link when importer is false but import data was completed" in {
+      val urlLink: String = controllers.correctReturn.routes.BroughtIntoUKController.onPageLoad(NormalMode).url
+      val renderedView = Jsoup.parse(view(NormalMode, urlLink)(FakeRequest(), implicitly).body)
+      renderedView.title() mustBe "You changed your soft drinks business activity - Soft Drinks Industry Levy - GOV.UK"
+      renderedView.getElementsByTag("h1").text() mustBe "You changed your soft drinks business activity"
+      renderedView.getElementsByTag("h1").attr("class") mustBe "govuk-heading-l"
+
+      val bodyText = renderedView.getElementsByClass("govuk-body").eachText()
+      bodyText.get(0) mustBe "In this return, you told us that you have packaged liable drinks in the UK."
+      bodyText.get(1) mustBe "This is different to your registered business activity, so we will update your registration."
+      bodyText.get(2) mustBe "If you made a mistake, you need to go back and change your answers."
+      bodyText.get(3) mustBe "If you’re happy with the change, select Update Registration."
+      renderedView.getElementsByTag("button").first().text() mustBe "Update registration"
+      val linkInBodyText = renderedView.getElementById("main-content").getElementsByTag("a")
+      linkInBodyText.attr("href") mustBe "/soft-drinks-industry-levy-variations-frontend/correct-return/brought-into-uk"
     }
 
     testBackLink(document)


### PR DESCRIPTION
Updated change registration controller to determine which page to redirect the user back to if they wish to change their answers, add subscription to post.  Also updated navigation to direct user to correct page based on user answers, and update/add tests for work completed